### PR TITLE
WIP: Use mapslices in LinearCombination

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Transforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,11 @@
 name = "Transforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.1"
+version = "0.1.0"
 
 [deps]
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -35,25 +35,23 @@ function apply(x::AbstractVector, LC::LinearCombination; inds=Colon())
 end
 
 """
-    apply(x::AbstractMatrix, LC::LinearCombination; dims=1, inds=Colon())
+    apply(A::AbstractMatrix, LC::LinearCombination; dims=2, inds=Colon())
 
-Applies the [`LinearCombination`](@ref) to each of the specified indices in `x` along the
-dimension specified, which defaults to applying it row-wise for each column of x.
+Applies the [`LinearCombination`](@ref) to each of the specified indices in `A` along the
+dimension specified, which defaults to applying it row-wise for each column of `A`.
 
 If no `inds` are specified, then the [`LinearCombination`](@ref) is applied to all columns.
 """
-function apply(x::AbstractMatrix, LC::LinearCombination; dims=1, inds=Colon())
+function apply(A::AbstractMatrix, LC::LinearCombination; dims=2, inds=Colon())
     if dims === Colon()
         throw(ArgumentError("Colon() dims is not supported, use 1 or 2 instead"))
     end
 
-    # Get the number of vectors in the dimension not specified
-    other_dim = dims ==  1 ? 2 : 1
-    num_inds = inds isa Colon ? size(x, other_dim) : length(inds)
-    # Error if dimensions don't match
+    # Check the number of vectors in the dimension specified - Error if dimensions don't match
+    num_inds = inds isa Colon ? size(A, dims) : length(inds)
     _check_dimensions_match(LC, num_inds)
 
-    return [_sum_row(row[inds], LC.coefficients) for row in eachslice(x; dims=dims)]
+    return mapslices(x -> _sum_row(x[inds], LC.coefficients), A; dims=dims)
 end
 
 """

--- a/src/one_hot_encoding.jl
+++ b/src/one_hot_encoding.jl
@@ -32,7 +32,7 @@ function _apply(x, encoding::OneHotEncoding; kwargs...)
 
     results = zeros(Int, length(x), n_categories)
 
-    for (i, value) in enumerate(x)
+    @views for (i, value) in enumerate(x)
         col_pos = encoding.categories[value]
         results[i, col_pos] = 1
     end

--- a/src/periodic.jl
+++ b/src/periodic.jl
@@ -43,11 +43,6 @@ function _apply(x, P::Periodic{T}; kwargs...) where T <: Period
     map(xi -> _periodic(P.f, xi, P.period, P.phase_shift), x)
 end
 
-function _apply!(x::AbstractArray{T}, P::Periodic; kwargs...) where T <: Real
-    x[:] = _apply(x, P; kwargs...)
-    return x
-end
-
 """
     _periodic(f, instant, period, phase_shift=Day(0))
 

--- a/src/power.jl
+++ b/src/power.jl
@@ -10,8 +10,3 @@ end
 function _apply(x::AbstractArray{T}, P::Power; kwargs...) where T <: Real
     return x .^ P.exponent
 end
-
-function _apply!(x::AbstractArray{T}, P::Power; kwargs...) where T <: Real
-    x[:] = _apply(x, P; kwargs...)
-    return x
-end

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -74,7 +74,7 @@ function compute_stats(table; cols=nothing)
     return (; μ_pairs...), (; σ_pairs...)
 end
 
-function _apply!(
+function _apply(
     A::AbstractArray, scaling::MeanStdScaling;
     name=nothing, inverse=false, eps=1e-3, kwargs...
 )
@@ -82,13 +82,12 @@ function _apply!(
     μ = scaling.mean[name]
     σ = scaling.std[name]
     if inverse
-        A[:] = μ .+ σ .* A
+        return μ .+ σ .* A
     else
         # Avoid division by 0
         # If std is 0 then data was uniform, so the scaled value would end up ≈ 0
         # Therefore the particular `eps` value should not matter much.
         σ_safe = σ == 0 ? eps : σ
-        A[:] = (A .- μ) ./ σ_safe
+        return (A .- μ) ./ σ_safe
     end
-    return A
 end

--- a/src/temporal.jl
+++ b/src/temporal.jl
@@ -5,5 +5,4 @@ Get the hour of day corresponding to the data.
 """
 struct HoD <: Transform end
 
-
 _apply(x, ::HoD; kwargs...) = hour.(x)

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -40,10 +40,10 @@ function apply end
 """
     apply!(data::T, ::Transform; kwargs...) -> T
 
-Applies the [`Transform`](@ref) mutating the input `data`. New transforms should usually
-only extend `_apply!` which this method delegates to.
+Applies the [`Transform`](@ref) mutating the input `data`. This method delegates to
+[`apply`](@ref) under the hood so does not need to be defined separately.
 
-Where necessary, this should be extended for new data types `T`.
+If [`Transform`](@ref) does not support mutation, this method will error.
 """
 function apply! end
 
@@ -136,7 +136,3 @@ function apply!(table::T, t::Transform; cols=nothing, kwargs...)::T where T
 
     return table
 end
-
-
-# Fallback method for when _apply is not directly defined
-_apply(x, t::Transform; kwargs...) = _apply!(_try_copy(x), t; kwargs...)

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -52,7 +52,11 @@ function apply! end
     apply(A::AbstractArray, ::Transform; dims=:, inds=:, kwargs...)
 
 Applies the [`Transform`](@ref) to the elements of `A`.
+
 Provide the `dims` keyword to apply the [`Transform`](@ref) along a certain dimension.
+For example, given a `Matrix`, `dims=1` applies to each column, while `dims=2` applies
+to each row.
+
 Provide the `inds` keyword to apply the [`Transform`](@ref) to certain indices along the
 `dims` specified.
 
@@ -83,12 +87,9 @@ end
     apply!(A::AbstractArray, ::Transform; dims=:, kwargs...)
 
 Applies the [`Transform`](@ref) to each element of `A`, mutating the data.
-Optionally specify the `dims` to apply the [`Transform`](@ref) along certain dimensions.
-For example in a `Matrix`, `dims=1` applies to each column, while `dims=2` applies
-to each row.
 """
-function apply!(A::AbstractArray, t::Transform; dims=:, kwargs...)
-    A[:] = apply(A, t; dims=dims, kwargs...)
+function apply!(A::AbstractArray, t::Transform; kwargs...)
+    A[:] = apply(A, t; kwargs...)
     return A
 end
 

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -72,12 +72,12 @@ function apply(A::AbstractArray, t::Transform; dims=:, inds=:, kwargs...)
         if inds === Colon()
             return _apply(A, t; kwargs...)
         else
-            return _apply(A[:][inds], t; kwargs...)
+            return @views _apply(A[:][inds], t; kwargs...)
         end
     end
 
     slice_index = 0
-    return mapslices(A, dims=dims) do x
+    return @views mapslices(A, dims=dims) do x
         slice_index += 1
         _apply(x[inds], t; name=Symbol(slice_index), kwargs...)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,14 +11,3 @@ function _try_copy(data)
         deepcopy(data)
     end
 end
-
-function invert_dims(A::AbstractArray, dims)
-    ndims(A) == 1 && return dims
-    # TODO: support named dims https://github.com/invenia/Transforms.jl/issues/20
-    inverted_dims = setdiff(1:ndims(A), dims)
-    if length(inverted_dims) == 1
-        inverted_dims = inverted_dims[1]
-    end
-
-    return inverted_dims
-end

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -33,7 +33,7 @@
 
     @testset "Matrix" begin
         M = [1 1; 2 2; 3 5]
-        expected = [0, 0, -2]
+        expected = hcat([0, 0, -2])
 
         @testset "all inds" begin
             @test Transforms.apply(M, lc) == expected
@@ -46,20 +46,20 @@
                 @test_throws ArgumentError Transforms.apply(M, lc; dims=d)
             end
 
-            @testset "dims = 1" begin
-                d = 1
+            @testset "dims = 2" begin
+                d = 2
                 @test Transforms.apply(M, lc; dims=d) == expected
                 @test lc(M; dims=d) == expected
             end
 
-            @testset "dims = 2" begin
-                d = 2
+            @testset "dims = 1" begin
+                d = 1
                 # There are 3 rows so trying to apply along dim 2 without specifying inds
                 # won't work
                 @test_throws DimensionMismatch Transforms.apply(M, lc; dims=d)
 
-                @test Transforms.apply(M, lc; dims=d, inds=[2, 3]) == [-1, -3]
-                @test lc(M; dims=d, inds=[1, 3]) == [-2, -4]
+                @test Transforms.apply(M, lc; dims=d, inds=[2, 3]) == [-1 -3]
+                @test lc(M; dims=d, inds=[1, 3]) == [-2 -4]
             end
         end
 
@@ -71,7 +71,7 @@
         @testset "specified inds" begin
             M = [1 1 5; 2 2 4]
             inds = [2, 3]
-            expected = [-4, -2]
+            expected = hcat([-4, -2])
 
             @test Transforms.apply(M, lc; inds=inds) == expected
             @test lc(M; inds=inds) == expected
@@ -80,7 +80,7 @@
 
     @testset "AxisArray" begin
         A = AxisArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
-        expected = [-1, -1]
+        expected = hcat([-1, -1])
 
         @testset "all inds" begin
             @test Transforms.apply(A, lc) == expected
@@ -93,16 +93,16 @@
                 @test_throws ArgumentError Transforms.apply(A, lc; dims=d)
             end
 
-            @testset "dims = 1" begin
-                d = 1
+            @testset "dims = 2" begin
+                d = 2
                 @test Transforms.apply(A, lc; dims=d) == expected
                 @test lc(A; dims=d) == expected
             end
 
-            @testset "dims = 2" begin
-                d = 2
-                @test Transforms.apply(A, lc; dims=d) == [-3, -3]
-                @test lc(A; dims=d) == [-3, -3]
+            @testset "dims = 1" begin
+                d = 1
+                @test Transforms.apply(A, lc; dims=d) == [-3 -3]
+                @test lc(A; dims=d) == [-3 -3]
             end
         end
 
@@ -114,7 +114,7 @@
         @testset "specified inds" begin
             A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
             inds = [1, 2]
-            expected = [-1, -1]
+            expected = hcat([-1, -1])
 
             @test Transforms.apply(A, lc; inds=inds) == expected
             @test lc(A; inds=inds) == expected
@@ -123,7 +123,7 @@
 
     @testset "AxisKey" begin
         A = KeyedArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
-        expected = [-1, -1]
+        expected = hcat([-1, -1])
 
         @testset "all inds" begin
             @test Transforms.apply(A, lc) == expected
@@ -136,16 +136,16 @@
                 @test_throws ArgumentError Transforms.apply(A, lc; dims=d)
             end
 
-            @testset "dims = 1" begin
-                d = 1
+            @testset "dims = 2" begin
+                d = 2
                 @test Transforms.apply(A, lc; dims=d) == expected
                 @test lc(A; dims=d) == expected
             end
 
-            @testset "dims = 2" begin
-                d = 2
-                @test Transforms.apply(A, lc; dims=d) == [-3, -3]
-                @test lc(A; dims=d) == [-3, -3]
+            @testset "dims = 1" begin
+                d = 1
+                @test Transforms.apply(A, lc; dims=d) == [-3 -3]
+                @test lc(A; dims=d) == [-3 -3]
             end
         end
 
@@ -157,7 +157,7 @@
         @testset "specified inds" begin
             A = KeyedArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
             inds = [1, 2]
-            expected = [-1, -1]
+            expected = hcat([-1, -1])
 
             @test Transforms.apply(A, lc; inds=inds) == expected
             @test lc(A; inds=inds) == expected

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,9 @@ using Transforms: _try_copy, _periodic
 using Test
 using TimeZones
 
+# TODO - this is needed to make mapslices work with AxisArrays - should be removed.
+AxisArrays.reduced_indices(X::Tuple{Vararg{Axis}}, r::UnitRange) = AxisArrays.reduced_indices(X, Tuple(collect(r)))
+
 @testset "Transforms.jl" begin
     include("linear_combination.jl")
     include("one_hot_encoding.jl")


### PR DESCRIPTION
Follow up to #25 

LinearCombination still uses eachslices, and thus still uses the opposite convention to `dims` compared to our other Transforms.

Before - no distinction between application to rows vs cols, default is `dims=1`
```julia
julia> A = [1 2 3; 4 5 6; 7 8 9];

julia> lc = LinearCombination([1, 2])
LinearCombination(Real[1, 2])

julia> Transforms.apply(A, lc; dims=1, inds=[1, 2])
3-element Array{Int64,1}:
  5
 14
 23

julia> Transforms.apply(A, lc; dims=2, inds=[1, 2])
3-element Array{Int64,1}:
  9
 12
 15
```

Now - applying to rows vs cols reduces the array accordingly, default is now `dims=2`
```julia
julia> A = [1 2 3; 4 5 6; 7 8 9];

julia> lc = LinearCombination([1, 2])
LinearCombination(Real[1, 2])

julia> Transforms.apply(A, lc; dims=1, inds=[1, 2])
1×3 Array{Int64,2}:
 9  12  15

julia> Transforms.apply(A, lc; dims=2, inds=[1, 2])
3×1 Array{Int64,2}:
  5
 14
```