### PR TITLE
Rename package to FeatureTransforms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "Transforms"
+name = "FeatureTransforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
 version = "0.1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureTransforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.1"
+version = "0.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# Transforms
+# FeatureTransforms
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/Transforms.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://invenia.github.io/Transforms.jl/dev)
-[![Build Status](https://travis-ci.com/invenia/Transforms.jl.svg?branch=master)](https://travis-ci.com/invenia/Transforms.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/FeatureTransforms.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://invenia.github.io/FeatureTransforms.jl/dev)
+[![Build Status](https://travis-ci.com/invenia/FeatureTransforms.jl.svg?branch=master)](https://travis-ci.com/invenia/FeatureTransforms.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
-Transforms.jl provides utilities for performing feature engineering in machine learning pipelines.
-Transforms supports operations on `AbstractArrays` and [Tables](https://github.com/JuliaData/Tables.jl).
+FeatureTransforms.jl provides utilities for performing feature engineering in machine learning pipelines.
+FeatureTransforms supports operations on `AbstractArrays` and [Tables](https://github.com/JuliaData/Tables.jl).
 
 ## Installation
 ```julia
-julia> using Pkg; Pkg.add("Transforms")
+julia> using Pkg; Pkg.add("FeatureTransforms")
 ```
 
 ## Quickstart
 Load in the dependencies and construct some toy data.
 ```julia
-julia> using DataFrames, Transforms
+julia> using DataFrames, FeatureTransforms
 
 julia> df = DataFrame(:a=>[1, 2, 3, 4, 5], :b=>[5, 4, 3, 2, 1], :c=>[0, 1, 0, 1, 0])
 5×3 DataFrame
@@ -36,11 +36,11 @@ Note that non-mutating transformations do not necessarily return the same type, 
 ```julia
 julia> p = Power(3);
 
-julia> Transforms.apply(df, p; cols=[:a])
+julia> FeatureTransforms.apply(df, p; cols=[:a])
 1-element Array{Array{Int64,1},1}:
  [1, 8, 27, 64, 125]
 
-julia> Transforms.apply!(df, p; cols=[:a])
+julia> FeatureTransforms.apply!(df, p; cols=[:a])
 5×3 DataFrame
  Row │ a      b      c     
      │ Int64  Int64  Int64 
@@ -57,7 +57,7 @@ But users may append the output to their data if they so wish.
 ```julia
 julia> lc = LinearCombination([1, -10]);
 
-julia> Transforms.apply(df, lc; cols=[:b, :c])
+julia> FeatureTransforms.apply(df, lc; cols=[:b, :c])
 5-element Array{Int64,1}:
   5
  -6

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -91,7 +91,7 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[[Transforms]]
+[[FeatureTransforms]]
 path = ".."
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 version = "0.1.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Transforms = "8fd68953-04b8-4117-ac19-158bf6de9782"
+FeatureTransforms = "8fd68953-04b8-4117-ac19-158bf6de9782"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,14 @@
-using Transforms
+using FeatureTransforms
 using Documenter
 
 makedocs(;
-    modules=[Transforms],
+    modules=[FeatureTransforms],
     authors="Invenia Technical Computing Corporation",
-    repo="https://github.com/invenia/Transforms.jl/blob/{commit}{path}#L{line}",
-    sitename="Transforms.jl",
+    repo="https://github.com/invenia/FeatureTransforms.jl/blob/{commit}{path}#L{line}",
+    sitename="FeatureTransforms.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://invenia.github.io/Transforms.jl",
+        canonical="https://invenia.github.io/FeatureTransforms.jl",
         assets=String[],
     ),
     pages=[
@@ -19,7 +19,7 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/invenia/Transforms.jl",
+    repo="github.com/invenia/FeatureTransforms.jl",
     devbranch = "main",
     push_preview = true,
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,12 +1,12 @@
 ```@meta
-CurrentModule = Transforms
+CurrentModule = FeatureTransforms
 ```
 
-# Transforms
+# FeatureTransforms
 
 ```@index
 ```
 
 ```@autodocs
-Modules = [Transforms]
+Modules = [FeatureTransforms]
 ```

--- a/src/FeatureTransforms.jl
+++ b/src/FeatureTransforms.jl
@@ -1,4 +1,4 @@
-module Transforms
+module FeatureTransforms
 
 using Dates: TimeType, Period, Day, hour
 using Statistics: mean, std

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -2,7 +2,7 @@
 """
     Transform
 
-Abstract supertype for all Transforms.
+Abstract supertype for all feature Transforms.
 """
 abstract type Transform end
 

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -8,17 +8,17 @@
         expected = [-1]
 
         @testset "all inds" begin
-            @test Transforms.apply(x, lc) == expected
+            @test FeatureTransforms.apply(x, lc) == expected
             @test lc(x) == expected
         end
 
         @testset "dims not supported" begin
-            @test_throws  MethodError Transforms.apply(x, lc; dims=1)
+            @test_throws  MethodError FeatureTransforms.apply(x, lc; dims=1)
         end
 
         @testset "dimension mismatch" begin
             x = [1, 2, 3]
-            @test_throws DimensionMismatch Transforms.apply(x, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(x, lc)
         end
 
         @testset "specified inds" begin
@@ -26,7 +26,7 @@
             inds = [2, 3]
             expected = [-1]
 
-            @test Transforms.apply(x, lc; inds=inds) == expected
+            @test FeatureTransforms.apply(x, lc; inds=inds) == expected
             @test lc(x; inds=inds) == expected
         end
     end
@@ -36,19 +36,19 @@
         expected = [0, 0, -2]
 
         @testset "all inds" begin
-            @test Transforms.apply(M, lc) == expected
+            @test FeatureTransforms.apply(M, lc) == expected
             @test lc(M) == expected
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
                 d = Colon()
-                @test_throws ArgumentError Transforms.apply(M, lc; dims=d)
+                @test_throws ArgumentError FeatureTransforms.apply(M, lc; dims=d)
             end
 
             @testset "dims = 1" begin
                 d = 1
-                @test Transforms.apply(M, lc; dims=d) == expected
+                @test FeatureTransforms.apply(M, lc; dims=d) == expected
                 @test lc(M; dims=d) == expected
             end
 
@@ -56,16 +56,16 @@
                 d = 2
                 # There are 3 rows so trying to apply along dim 2 without specifying inds
                 # won't work
-                @test_throws DimensionMismatch Transforms.apply(M, lc; dims=d)
+                @test_throws DimensionMismatch FeatureTransforms.apply(M, lc; dims=d)
 
-                @test Transforms.apply(M, lc; dims=d, inds=[2, 3]) == [-1, -3]
+                @test FeatureTransforms.apply(M, lc; dims=d, inds=[2, 3]) == [-1, -3]
                 @test lc(M; dims=d, inds=[1, 3]) == [-2, -4]
             end
         end
 
         @testset "dimension mismatch" begin
             M = [1 1 1; 2 2 2]
-            @test_throws DimensionMismatch Transforms.apply(M, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(M, lc)
         end
 
         @testset "specified inds" begin
@@ -73,7 +73,7 @@
             inds = [2, 3]
             expected = [-4, -2]
 
-            @test Transforms.apply(M, lc; inds=inds) == expected
+            @test FeatureTransforms.apply(M, lc; inds=inds) == expected
             @test lc(M; inds=inds) == expected
         end
     end
@@ -83,32 +83,32 @@
         expected = [-1, -1]
 
         @testset "all inds" begin
-            @test Transforms.apply(A, lc) == expected
+            @test FeatureTransforms.apply(A, lc) == expected
             @test lc(A) == expected
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
                 d = Colon()
-                @test_throws ArgumentError Transforms.apply(A, lc; dims=d)
+                @test_throws ArgumentError FeatureTransforms.apply(A, lc; dims=d)
             end
 
             @testset "dims = 1" begin
                 d = 1
-                @test Transforms.apply(A, lc; dims=d) == expected
+                @test FeatureTransforms.apply(A, lc; dims=d) == expected
                 @test lc(A; dims=d) == expected
             end
 
             @testset "dims = 2" begin
                 d = 2
-                @test Transforms.apply(A, lc; dims=d) == [-3, -3]
+                @test FeatureTransforms.apply(A, lc; dims=d) == [-3, -3]
                 @test lc(A; dims=d) == [-3, -3]
             end
         end
 
         @testset "dimension mismatch" begin
             A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            @test_throws DimensionMismatch Transforms.apply(A, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(A, lc)
         end
 
         @testset "specified inds" begin
@@ -116,7 +116,7 @@
             inds = [1, 2]
             expected = [-1, -1]
 
-            @test Transforms.apply(A, lc; inds=inds) == expected
+            @test FeatureTransforms.apply(A, lc; inds=inds) == expected
             @test lc(A; inds=inds) == expected
         end
     end
@@ -126,32 +126,32 @@
         expected = [-1, -1]
 
         @testset "all inds" begin
-            @test Transforms.apply(A, lc) == expected
+            @test FeatureTransforms.apply(A, lc) == expected
             @test lc(A) == expected
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
                 d = Colon()
-                @test_throws ArgumentError Transforms.apply(A, lc; dims=d)
+                @test_throws ArgumentError FeatureTransforms.apply(A, lc; dims=d)
             end
 
             @testset "dims = 1" begin
                 d = 1
-                @test Transforms.apply(A, lc; dims=d) == expected
+                @test FeatureTransforms.apply(A, lc; dims=d) == expected
                 @test lc(A; dims=d) == expected
             end
 
             @testset "dims = 2" begin
                 d = 2
-                @test Transforms.apply(A, lc; dims=d) == [-3, -3]
+                @test FeatureTransforms.apply(A, lc; dims=d) == [-3, -3]
                 @test lc(A; dims=d) == [-3, -3]
             end
         end
 
         @testset "dimension mismatch" begin
             A = KeyedArray([1 2 3; 4 5 6], foo=["a", "b"], bar=["x", "y", "z"])
-            @test_throws DimensionMismatch Transforms.apply(A, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(A, lc)
         end
 
         @testset "specified inds" begin
@@ -159,7 +159,7 @@
             inds = [1, 2]
             expected = [-1, -1]
 
-            @test Transforms.apply(A, lc; inds=inds) == expected
+            @test FeatureTransforms.apply(A, lc; inds=inds) == expected
             @test lc(A; inds=inds) == expected
         end
     end
@@ -169,17 +169,17 @@
         expected = [-3, -3, -3]
 
         @testset "all cols" begin
-            @test Transforms.apply(nt, lc) == expected
+            @test FeatureTransforms.apply(nt, lc) == expected
             @test lc(nt) == expected
         end
 
         @testset "dims not supported" begin
-            @test_throws MethodError Transforms.apply(nt, lc; dims=1)
+            @test_throws MethodError FeatureTransforms.apply(nt, lc; dims=1)
         end
 
         @testset "dimension mismatch" begin
             nt = (a = [1, 2, 3], b = [4, 5, 6], c = [1, 1, 1])
-            @test_throws DimensionMismatch Transforms.apply(nt, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(nt, lc)
         end
 
         @testset "specified cols" begin
@@ -187,15 +187,15 @@
             cols = [:a, :b]
             expected = [-3, -3, -3]
 
-            @test Transforms.apply(nt, lc; cols=cols) == expected
+            @test FeatureTransforms.apply(nt, lc; cols=cols) == expected
             @test lc(nt; cols=cols) == expected
         end
 
         @testset "single col" begin
             lc_single = LinearCombination([-1])
 
-            @test Transforms.apply(nt, lc_single; cols=:a) == [-1, -2, -3]
-            @test Transforms.apply(nt, lc_single; cols=[:a]) == [-1, -2, -3]
+            @test FeatureTransforms.apply(nt, lc_single; cols=:a) == [-1, -2, -3]
+            @test FeatureTransforms.apply(nt, lc_single; cols=[:a]) == [-1, -2, -3]
             @test lc_single(nt; cols=:a) == [-1, -2, -3]
         end
     end
@@ -205,17 +205,17 @@
         expected = [-3, -3, -3]
 
         @testset "all cols" begin
-            @test Transforms.apply(df, lc) == expected
+            @test FeatureTransforms.apply(df, lc) == expected
             @test lc(df) == expected
         end
 
         @testset "dims not supported" begin
-            @test_throws MethodError Transforms.apply(df, lc; dims=1)
+            @test_throws MethodError FeatureTransforms.apply(df, lc; dims=1)
         end
 
         @testset "dimension mismatch" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [1, 1, 1])
-            @test_throws DimensionMismatch Transforms.apply(df, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(df, lc)
         end
 
         @testset "specified cols" begin
@@ -223,15 +223,15 @@
             cols = [:b, :c]
             expected = [3, 4, 5]
 
-            @test Transforms.apply(df, lc; cols=cols) == expected
+            @test FeatureTransforms.apply(df, lc; cols=cols) == expected
             @test lc(df; cols=cols) == expected
         end
 
         @testset "single col" begin
             lc_single = LinearCombination([-1])
 
-            @test Transforms.apply(df, lc_single; cols=:a) == [-1, -2, -3]
-            @test Transforms.apply(df, lc_single; cols=[:a]) == [-1, -2, -3]
+            @test FeatureTransforms.apply(df, lc_single; cols=:a) == [-1, -2, -3]
+            @test FeatureTransforms.apply(df, lc_single; cols=[:a]) == [-1, -2, -3]
             @test lc_single(df; cols=:a) == [-1, -2, -3]
         end
     end

--- a/test/one_hot_encoding.jl
+++ b/test/one_hot_encoding.jl
@@ -8,37 +8,37 @@
         x = ["foo", "bar", "baz"]
         expected = [1 0 0; 0 1 0; 0 0 1]
 
-        transformed = Transforms.apply(x, ohe)
+        transformed = FeatureTransforms.apply(x, ohe)
         @test transformed == expected
         @test transformed isa AbstractMatrix{Bool}
         @test ohe(x) == expected
 
         # Test specifying return type
-        transformed = Transforms.apply(x, OneHotEncoding{AbstractFloat}(categories))
+        transformed = FeatureTransforms.apply(x, OneHotEncoding{AbstractFloat}(categories))
         @test transformed == expected
         @test transformed isa AbstractMatrix{AbstractFloat}
 
         # Test duplicate values
         x = ["foo", "baz", "bar", "baz"]
         expected = [1 0 0; 0 0 1; 0 1 0; 0 0 1]
-        @test Transforms.apply(x, ohe) == expected
+        @test FeatureTransforms.apply(x, ohe) == expected
 
         # Test cannot pass duplicate values as the categories
         @test_throws ArgumentError OneHotEncoding(x)
 
         # Test a value does not exist as a category
         x = ["foo", "baz", "bar", "dne"]
-        @test_throws KeyError Transforms.apply(x, ohe)
+        @test_throws KeyError FeatureTransforms.apply(x, ohe)
 
         @testset "inds" begin
              x = ["foo", "baz", "bar", "baz"]
-            @test Transforms.apply(x, ohe; inds=2:4) == [0 0 1; 0 1 0; 0 0 1]
-            @test Transforms.apply(x, ohe; dims=:) == expected
+            @test FeatureTransforms.apply(x, ohe; inds=2:4) == [0 0 1; 0 1 0; 0 0 1]
+            @test FeatureTransforms.apply(x, ohe; dims=:) == expected
 
-            @test_throws DimensionMismatch Transforms.apply(x, ohe; dims=1)
-            @test_throws DimensionMismatch Transforms.apply(x, ohe; dims=1, inds=[2, 4])
+            @test_throws DimensionMismatch FeatureTransforms.apply(x, ohe; dims=1)
+            @test_throws DimensionMismatch FeatureTransforms.apply(x, ohe; dims=1, inds=[2, 4])
 
-            @test_throws BoundsError Transforms.apply(x, ohe; dims=2)
+            @test_throws BoundsError FeatureTransforms.apply(x, ohe; dims=2)
         end
     end
 
@@ -49,17 +49,17 @@
         M = ["foo" "bar"; "foo2" "bar2"]
         expected = [1 0 0 0 0; 0 0 0 1 0; 0 1 0 0 0; 0 0 0 0 1]
 
-        @test Transforms.apply(M, ohe) == expected
+        @test FeatureTransforms.apply(M, ohe) == expected
 
         @testset "dims" begin
-            @test Transforms.apply(M, ohe; dims=:) == expected
-            @test_throws DimensionMismatch Transforms.apply(M, ohe; dims=1)
-            @test_throws DimensionMismatch Transforms.apply(M, ohe; dims=2)
+            @test FeatureTransforms.apply(M, ohe; dims=:) == expected
+            @test_throws DimensionMismatch FeatureTransforms.apply(M, ohe; dims=1)
+            @test_throws DimensionMismatch FeatureTransforms.apply(M, ohe; dims=2)
         end
 
         @testset "inds" begin
-            @test Transforms.apply(M, ohe; inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
-            @test Transforms.apply(M, ohe; dims=:, inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
+            @test FeatureTransforms.apply(M, ohe; inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
+            @test FeatureTransforms.apply(M, ohe; dims=:, inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
         end
     end
 
@@ -69,18 +69,18 @@
         expected = [1 0 0 0 0; 0 0 0 1 0; 0 1 0 0 0; 0 0 0 0 1]
 
         @testset "dims" begin
-            transformed = Transforms.apply(A, ohe; dims=:)
+            transformed = FeatureTransforms.apply(A, ohe; dims=:)
             # AxisArray doesn't preserve the type it operates on
             @test transformed isa AbstractArray
             @test transformed == expected
 
-            @test_throws DimensionMismatch Transforms.apply(A, ohe; dims=1)
-            @test_throws DimensionMismatch Transforms.apply(A, ohe; dims=2)
+            @test_throws DimensionMismatch FeatureTransforms.apply(A, ohe; dims=1)
+            @test_throws DimensionMismatch FeatureTransforms.apply(A, ohe; dims=2)
         end
 
         @testset "inds" begin
-            @test Transforms.apply(A, ohe; inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
-            @test Transforms.apply(A, ohe; dims=:, inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
+            @test FeatureTransforms.apply(A, ohe; inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
+            @test FeatureTransforms.apply(A, ohe; dims=:, inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
         end
     end
 
@@ -90,18 +90,18 @@
         expected = [1 0 0 0 0; 0 0 0 1 0; 0 1 0 0 0; 0 0 0 0 1]
 
         @testset "dims" begin
-            transformed = Transforms.apply(A, ohe; dims=:)
+            transformed = FeatureTransforms.apply(A, ohe; dims=:)
             # This transform doesn't preserve the type it operates on
             @test transformed isa AbstractArray
             @test transformed == expected
 
-            @test_throws DimensionMismatch Transforms.apply(A, ohe; dims=1)
-            @test_throws DimensionMismatch Transforms.apply(A, ohe; dims=2)
+            @test_throws DimensionMismatch FeatureTransforms.apply(A, ohe; dims=1)
+            @test_throws DimensionMismatch FeatureTransforms.apply(A, ohe; dims=2)
         end
 
         @testset "inds" begin
-            @test Transforms.apply(A, ohe; inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
-            @test Transforms.apply(A, ohe; dims=:, inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
+            @test FeatureTransforms.apply(A, ohe; inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
+            @test FeatureTransforms.apply(A, ohe; dims=:, inds=[2, 3]) == [0 0 0 1 0; 0 1 0 0 0]
         end
     end
 
@@ -111,13 +111,13 @@
         expected = [expected_nt.a, expected_nt.b]
 
         @testset "all cols" begin
-            @test Transforms.apply(nt, ohe) == expected
+            @test FeatureTransforms.apply(nt, ohe) == expected
             @test ohe(nt) == expected
         end
 
         @testset "cols = $c" for c in (:a, :b)
-            @test Transforms.apply(nt, ohe; cols=[c]) == [expected_nt[c]]
-            @test Transforms.apply(nt, ohe; cols=c) == expected_nt[c]
+            @test FeatureTransforms.apply(nt, ohe; cols=[c]) == [expected_nt[c]]
+            @test FeatureTransforms.apply(nt, ohe; cols=c) == expected_nt[c]
             @test ohe(nt; cols=[c]) == [expected_nt[c]]
         end
     end
@@ -126,10 +126,10 @@
         df = DataFrame(:a => ["foo", "bar"], :b => ["foo2", "bar2"])
         expected = [[1 0 0 0 0; 0 1 0 0 0], [0 0 0 1 0; 0 0 0 0 1]]
 
-        @test Transforms.apply(df, ohe) == expected
+        @test FeatureTransforms.apply(df, ohe) == expected
 
-        @test Transforms.apply(df, ohe; cols=[:a]) == [[1 0 0 0 0; 0 1 0 0 0]]
-        @test Transforms.apply(df, ohe; cols=:a) == [1 0 0 0 0; 0 1 0 0 0]
-        @test Transforms.apply(df, ohe; cols=[:b]) ==[[0 0 0 1 0; 0 0 0 0 1]]
+        @test FeatureTransforms.apply(df, ohe; cols=[:a]) == [[1 0 0 0 0; 0 1 0 0 0]]
+        @test FeatureTransforms.apply(df, ohe; cols=:a) == [1 0 0 0 0; 0 1 0 0 0]
+        @test FeatureTransforms.apply(df, ohe; cols=[:b]) ==[[0 0 0 1 0; 0 0 0 0 1]]
     end
 end

--- a/test/periodic.jl
+++ b/test/periodic.jl
@@ -74,7 +74,7 @@
                 p = Periodic(sin, 4.0, 2)
                 x = [2.0, 3.0, 5.0]
 
-                @test Transforms.apply(x, p) ≈ [0.0, 1.0, -1.0] atol=1e-14
+                @test FeatureTransforms.apply(x, p) ≈ [0.0, 1.0, -1.0] atol=1e-14
                 @test p(x) ≈ [0.0, 1.0, -1.0] atol=1e-14
             end
         end
@@ -105,20 +105,20 @@
             @testset "Vector" begin
                 x = collect(0.:5.)
 
-                @test Transforms.apply(x, p) ≈ expected atol=1e-14
+                @test FeatureTransforms.apply(x, p) ≈ expected atol=1e-14
                 @test p(x) ≈ expected atol=1e-14
 
                 _x = copy(x)
-                Transforms.apply!(_x, p)
+                FeatureTransforms.apply!(_x, p)
                 @test _x ≈ expected atol=1e-14
 
                 @testset "inds" begin
-                    @test Transforms.apply(x, p; inds=2:5) ≈ expected[2:5] atol=1e-14
-                    @test Transforms.apply(x, p; dims=:) ≈ expected atol=1e-14
-                    @test Transforms.apply(x, p; dims=1) ≈ expected atol=1e-14
-                    @test Transforms.apply(x, p; dims=1, inds=[2, 3, 4, 5]) ≈ expected[2:5] atol=1e-14
+                    @test FeatureTransforms.apply(x, p; inds=2:5) ≈ expected[2:5] atol=1e-14
+                    @test FeatureTransforms.apply(x, p; dims=:) ≈ expected atol=1e-14
+                    @test FeatureTransforms.apply(x, p; dims=1) ≈ expected atol=1e-14
+                    @test FeatureTransforms.apply(x, p; dims=1, inds=[2, 3, 4, 5]) ≈ expected[2:5] atol=1e-14
 
-                    @test_throws BoundsError Transforms.apply(x, p; dims=2)
+                    @test_throws BoundsError FeatureTransforms.apply(x, p; dims=2)
                 end
             end
 
@@ -128,19 +128,19 @@
                 M_expected = reshape(expected, (3, 2))
 
                 @testset "dims = $d" for d in (Colon(), 1, 2)
-                    @test Transforms.apply(M, p; dims=d) ≈ M_expected atol=1e-14
+                    @test FeatureTransforms.apply(M, p; dims=d) ≈ M_expected atol=1e-14
                     @test p(M; dims=d) ≈ M_expected atol=1e-14
 
                     _M = copy(M)
-                    Transforms.apply!(_M, p; dims=d)
+                    FeatureTransforms.apply!(_M, p; dims=d)
                     @test _M ≈ M_expected atol=1e-14
                 end
 
                 @testset "inds" begin
-                    @test Transforms.apply(M, p; inds=[2, 3]) ≈ M_expected[[2, 3]] atol=1e-14
-                    @test Transforms.apply(M, p; dims=:, inds=[2, 3]) ≈ M_expected[[2, 3]] atol=1e-14
-                    @test Transforms.apply(M, p; dims=1, inds=[2]) ≈ reshape(M_expected[[2, 5]], 1, 2) atol=1e-14
-                    @test Transforms.apply(M, p; dims=2, inds=[2]) ≈ reshape(M_expected[[4, 5, 6]], 3, 1) atol=1e-14
+                    @test FeatureTransforms.apply(M, p; inds=[2, 3]) ≈ M_expected[[2, 3]] atol=1e-14
+                    @test FeatureTransforms.apply(M, p; dims=:, inds=[2, 3]) ≈ M_expected[[2, 3]] atol=1e-14
+                    @test FeatureTransforms.apply(M, p; dims=1, inds=[2]) ≈ reshape(M_expected[[2, 5]], 1, 2) atol=1e-14
+                    @test FeatureTransforms.apply(M, p; dims=2, inds=[2]) ≈ reshape(M_expected[[4, 5, 6]], 3, 1) atol=1e-14
                 end
             end
 
@@ -155,22 +155,22 @@
                 )
 
                 @testset "dims = $d" for d in (Colon(), 1, 2)
-                    transformed = Transforms.apply(A, p; dims=d)
+                    transformed = FeatureTransforms.apply(A, p; dims=d)
                     # AxisArray doesn't preserve type when operations are performed on it
                     @test transformed isa AbstractArray
                     @test transformed ≈ A_expected atol=1e-14
                 end
 
                 _A = copy(A)
-                Transforms.apply!(_A, p)
+                FeatureTransforms.apply!(_A, p)
                 @test _A isa AxisArray
                 @test _A ≈ A_expected atol=1e-14
 
                 @testset "inds" begin
-                    @test Transforms.apply(A, p; inds=[2, 3]) ≈ A_expected[[2, 3]] atol=1e-14
-                    @test Transforms.apply(A, p; dims=:, inds=[2, 3]) ≈ A_expected[[2, 3]] atol=1e-14
-                    @test Transforms.apply(A, p; dims=1, inds=[2]) ≈ reshape(A_expected[[2, 5]], 1, 2) atol=1e-14
-                    @test Transforms.apply(A, p; dims=2, inds=[2]) ≈ reshape(A_expected[[4, 5, 6]], 3, 1) atol=1e-14
+                    @test FeatureTransforms.apply(A, p; inds=[2, 3]) ≈ A_expected[[2, 3]] atol=1e-14
+                    @test FeatureTransforms.apply(A, p; dims=:, inds=[2, 3]) ≈ A_expected[[2, 3]] atol=1e-14
+                    @test FeatureTransforms.apply(A, p; dims=1, inds=[2]) ≈ reshape(A_expected[[2, 5]], 1, 2) atol=1e-14
+                    @test FeatureTransforms.apply(A, p; dims=2, inds=[2]) ≈ reshape(A_expected[[4, 5, 6]], 3, 1) atol=1e-14
                 end
             end
 
@@ -185,20 +185,20 @@
                 )
 
                 @testset "dims = $d" for d in (Colon(), :foo, :bar)
-                    transformed = Transforms.apply(A, p; dims=d)
+                    transformed = FeatureTransforms.apply(A, p; dims=d)
                     @test transformed isa KeyedArray
                     @test transformed ≈ A_expected atol=1e-14
                 end
 
                 _A = copy(A)
-                Transforms.apply!(_A, p)
+                FeatureTransforms.apply!(_A, p)
                 @test _A ≈ A_expected atol=1e-14
 
                 @testset "inds" begin
-                    @test Transforms.apply(A, p; inds=[2, 3]) ≈ [A_expected[2], A_expected[3]] atol=1e-14
-                    @test Transforms.apply(A, p; dims=:, inds=[2, 3]) ≈ [A_expected[2], A_expected[3]] atol=1e-14
-                    @test Transforms.apply(A, p; dims=1, inds=[2]) ≈ reshape([A_expected[2], A_expected[5]], 1, 2) atol=1e-14
-                    @test Transforms.apply(A, p; dims=2, inds=[2]) ≈ reshape([A_expected[4], A_expected[5], A_expected[6]], 3, 1) atol=1e-14
+                    @test FeatureTransforms.apply(A, p; inds=[2, 3]) ≈ [A_expected[2], A_expected[3]] atol=1e-14
+                    @test FeatureTransforms.apply(A, p; dims=:, inds=[2, 3]) ≈ [A_expected[2], A_expected[3]] atol=1e-14
+                    @test FeatureTransforms.apply(A, p; dims=1, inds=[2]) ≈ reshape([A_expected[2], A_expected[5]], 1, 2) atol=1e-14
+                    @test FeatureTransforms.apply(A, p; dims=2, inds=[2]) ≈ reshape([A_expected[4], A_expected[5], A_expected[6]], 3, 1) atol=1e-14
                 end
             end
 
@@ -207,12 +207,12 @@
                 nt_expected = (a = expected[1:3], b = expected[4:6])
 
                 @testset "all cols" begin
-                    transformed = Transforms.apply(nt, p)
+                    transformed = FeatureTransforms.apply(nt, p)
                     @test transformed ≈ collect(nt_expected) atol=1e-14
                     @test p(nt) ≈ collect(nt_expected) atol=1e-14
 
                     _nt = deepcopy(nt)
-                    Transforms.apply!(_nt, p)
+                    FeatureTransforms.apply!(_nt, p)
                     @test _nt isa NamedTuple{(:a, :b)}
                     @test collect(_nt) ≈ collect(nt_expected) atol=1e-14
                 end
@@ -221,13 +221,13 @@
                     nt_mutated = NamedTuple{(Symbol("$c"), )}((nt_expected[c], ))
                     nt_expected_ = merge(nt, nt_mutated)
 
-                    @test Transforms.apply(nt, p; cols=[c]) ≈ [collect(nt_expected_[c])] atol=1e-14
-                    @test Transforms.apply(nt, p; cols=c) ≈ collect(nt_expected_[c]) atol=1e-14
+                    @test FeatureTransforms.apply(nt, p; cols=[c]) ≈ [collect(nt_expected_[c])] atol=1e-14
+                    @test FeatureTransforms.apply(nt, p; cols=c) ≈ collect(nt_expected_[c]) atol=1e-14
                     @test p(nt; cols=[c]) ≈ [collect(nt_expected_[c])] atol=1e-14
 
                     @testset "mutating" for _c in (c, [c])
                         _nt = deepcopy(nt)
-                        Transforms.apply!(_nt, p; cols=_c)
+                        FeatureTransforms.apply!(_nt, p; cols=_c)
                         @test _nt isa NamedTuple{(:a, :b)}  # before applying `collect`
                         @test collect(_nt) ≈ collect(nt_expected_) atol=1e-14
                     end
@@ -239,18 +239,18 @@
                 df_expected = DataFrame(:a => expected[1:3], :b => expected[4:6])
 
                 @testset "all cols" begin
-                    @test Transforms.apply(df, p) ≈ [df_expected.a, df_expected.b] atol=1e-14
+                    @test FeatureTransforms.apply(df, p) ≈ [df_expected.a, df_expected.b] atol=1e-14
                     @test p(df) ≈ [df_expected.a, df_expected.b] atol=1e-14
 
                     _df = deepcopy(df)
-                    Transforms.apply!(_df, p)
+                    FeatureTransforms.apply!(_df, p)
                     @test _df isa DataFrame
                     @test _df ≈ df_expected atol=1e-14
                 end
 
                 @testset "cols = $c" for c in (:a, :b)
-                    @test Transforms.apply(df, p; cols=[c]) ≈ [df_expected[!, c]] atol=1e-14
-                    @test Transforms.apply(df, p; cols=c) ≈ df_expected[!, c] atol=1e-14
+                    @test FeatureTransforms.apply(df, p; cols=[c]) ≈ [df_expected[!, c]] atol=1e-14
+                    @test FeatureTransforms.apply(df, p; cols=c) ≈ df_expected[!, c] atol=1e-14
                     @test p(df; cols=[c]) ≈ [df_expected[!, c]]
                 end
             end
@@ -285,7 +285,7 @@
                 # Use _periodic to get expected outputs because we test it elsewhere
                 expected = _periodic.(sin, x, Week(1), Day(5))
 
-                @test Transforms.apply(x, p) ≈ expected atol=1e-14
+                @test FeatureTransforms.apply(x, p) ≈ expected atol=1e-14
                 @test p(x) ≈ expected atol=1e-14
             end
         end
@@ -298,7 +298,7 @@
                 # Use _periodic to get expected outputs because we test it elsewhere
                 expected = _periodic.(f, x, Day(5), Day(2))
 
-                @test Transforms.apply(x, p) ≈ expected atol=1e-14
+                @test FeatureTransforms.apply(x, p) ≈ expected atol=1e-14
                 @test p(x) ≈ expected atol=1e-14
             end
 
@@ -309,7 +309,7 @@
                 expected = reshape(expected, (3, 2))
 
                 @testset "dims = $d" for d in (Colon(), 1, 2)
-                    @test Transforms.apply(M, p; dims=d) ≈ expected atol=1e-14
+                    @test FeatureTransforms.apply(M, p; dims=d) ≈ expected atol=1e-14
                     @test p(M; dims=d) ≈ expected atol=1e-14
                 end
             end
@@ -330,7 +330,7 @@
                 )
 
                 @testset "dims = $d" for d in (Colon(), 1, 2)
-                    transformed = Transforms.apply(A, p; dims=d)
+                    transformed = FeatureTransforms.apply(A, p; dims=d)
                     # AxisArray doesn't preserve type when operations are performed on it
                     @test transformed isa AbstractArray
                     @test transformed ≈ expected atol=1e-14
@@ -353,7 +353,7 @@
                 )
 
                 @testset "dims = $d" for d in (Colon(), :foo, :bar)
-                    transformed = Transforms.apply(A, p; dims=d)
+                    transformed = FeatureTransforms.apply(A, p; dims=d)
                     @test transformed isa KeyedArray
                     @test transformed ≈ expected atol=1e-14
                 end
@@ -368,15 +368,15 @@
                 ]
 
                 @testset "all cols" begin
-                    transformed = Transforms.apply(nt, p)
+                    transformed = FeatureTransforms.apply(nt, p)
                     @test transformed ≈ expected atol=1e-14
                     @test p(nt) ≈ expected atol=1e-14
                 end
 
                 nt_expected = (a = expected[1], b = expected[2])
                 @testset "cols = $c" for c in (:a, :b)
-                    @test Transforms.apply(nt, p; cols=[c]) ≈ [nt_expected[c]] atol=1e-14
-                    @test Transforms.apply(nt, p; cols=c) ≈ nt_expected[c] atol=1e-14
+                    @test FeatureTransforms.apply(nt, p; cols=[c]) ≈ [nt_expected[c]] atol=1e-14
+                    @test FeatureTransforms.apply(nt, p; cols=c) ≈ nt_expected[c] atol=1e-14
                     @test p(nt; cols=[c]) ≈ [nt_expected[c]] atol=1e-14
                 end
             end
@@ -389,12 +389,12 @@
                     :b => _periodic.(f, x[4:6], Day(5), Day(2))
                 )
 
-                transformed = Transforms.apply(df, p)
+                transformed = FeatureTransforms.apply(df, p)
                 @test transformed ≈ [df_expected.a, df_expected.b] atol=1e-14
 
                 @testset "cols = $c" for c in (:a, :b)
-                    @test Transforms.apply(df, p; cols=[c]) ≈ [df_expected[!, c]] atol=1e-14
-                    @test Transforms.apply(df, p; cols=c) ≈ df_expected[!, c] atol=1e-14
+                    @test FeatureTransforms.apply(df, p; cols=[c]) ≈ [df_expected[!, c]] atol=1e-14
+                    @test FeatureTransforms.apply(df, p; cols=c) ≈ df_expected[!, c] atol=1e-14
                     @test p(df; cols=[c]) ≈ [df_expected[!, c]] atol=1e-14
                 end
             end
@@ -405,13 +405,13 @@
         @testset "Real data, Period transform" begin
             p = Periodic(sin, Day(5), Day(2))
             x = 0.:11.
-            @test_throws MethodError Transforms.apply(x, p)
+            @test_throws MethodError FeatureTransforms.apply(x, p)
         end
 
         @testset "TimeType data, Real transform" begin
             p = Periodic(sin, 5, 2)
             x = ZonedDateTime(2020, 1, 1, tz"EST") .+ (Day(0):Day(1):Day(5))
-            @test_throws MethodError Transforms.apply(x, p)
+            @test_throws MethodError FeatureTransforms.apply(x, p)
         end
 
         @test_throws ArgumentError Periodic(sin, 1, Day(3))

--- a/test/power.jl
+++ b/test/power.jl
@@ -8,20 +8,20 @@
         x = [1, 2, 3, 4, 5]
         expected = [1, 8, 27, 64, 125]
 
-        @test Transforms.apply(x, p) == expected
+        @test FeatureTransforms.apply(x, p) == expected
         @test p(x) == expected
 
         _x = copy(x)
-        Transforms.apply!(_x, p)
+        FeatureTransforms.apply!(_x, p)
         @test _x == expected
 
         @testset "inds" begin
-            @test Transforms.apply(x, p; inds=2:5) ==  expected[2:5]
-            @test Transforms.apply(x, p; dims=:) == expected
-            @test Transforms.apply(x, p; dims=1) == expected
-            @test Transforms.apply(x, p; dims=1, inds=[2, 3, 4, 5]) == expected[2:5]
+            @test FeatureTransforms.apply(x, p; inds=2:5) ==  expected[2:5]
+            @test FeatureTransforms.apply(x, p; dims=:) == expected
+            @test FeatureTransforms.apply(x, p; dims=1) == expected
+            @test FeatureTransforms.apply(x, p; dims=1, inds=[2, 3, 4, 5]) == expected[2:5]
 
-            @test_throws BoundsError Transforms.apply(x, p; dims=2)
+            @test_throws BoundsError FeatureTransforms.apply(x, p; dims=2)
         end
     end
 
@@ -30,19 +30,19 @@
         expected = [1 8 27; 64 125 216]
 
         @testset "dims = $d" for d in (Colon(), 1, 2)
-            @test Transforms.apply(M, p; dims=d) == expected
+            @test FeatureTransforms.apply(M, p; dims=d) == expected
             @test p(M; dims=d) == expected
 
             _M = copy(M)
-            Transforms.apply!(_M, p; dims=d)
+            FeatureTransforms.apply!(_M, p; dims=d)
             @test _M == expected
         end
 
         @testset "inds" begin
-            @test Transforms.apply(M, p; inds=[2, 3]) == expected[[2, 3]]
-            @test Transforms.apply(M, p; dims=:, inds=[2, 3]) == expected[[2, 3]]
-            @test Transforms.apply(M, p; dims=1, inds=[2]) == [64 125 216]
-            @test Transforms.apply(M, p; dims=2, inds=[2]) == reshape([8, 125], 2, 1)
+            @test FeatureTransforms.apply(M, p; inds=[2, 3]) == expected[[2, 3]]
+            @test FeatureTransforms.apply(M, p; dims=:, inds=[2, 3]) == expected[[2, 3]]
+            @test FeatureTransforms.apply(M, p; dims=1, inds=[2]) == [64 125 216]
+            @test FeatureTransforms.apply(M, p; dims=2, inds=[2]) == reshape([8, 125], 2, 1)
         end
     end
 
@@ -51,22 +51,22 @@
         expected = [1 8 27; 64 125 216]
 
         @testset "dims = $d" for d in (Colon(), 1, 2)
-            transformed = Transforms.apply(A, p; dims=d)
+            transformed = FeatureTransforms.apply(A, p; dims=d)
             # AxisArray doesn't preserve the type it operates on
             @test transformed isa AbstractArray
             @test transformed == expected
         end
 
         _A = copy(A)
-        Transforms.apply!(_A, p)
+        FeatureTransforms.apply!(_A, p)
         @test _A isa AxisArray
         @test _A == expected
 
         @testset "inds" begin
-            @test Transforms.apply(A, p; inds=[2, 3]) == expected[[2, 3]]
-            @test Transforms.apply(A, p; dims=:, inds=[2, 3]) == expected[[2, 3]]
-            @test Transforms.apply(A, p; dims=1, inds=[2]) == [64 125 216]
-            @test Transforms.apply(A, p; dims=2, inds=[2]) == reshape([8, 125], 2, 1)
+            @test FeatureTransforms.apply(A, p; inds=[2, 3]) == expected[[2, 3]]
+            @test FeatureTransforms.apply(A, p; dims=:, inds=[2, 3]) == expected[[2, 3]]
+            @test FeatureTransforms.apply(A, p; dims=1, inds=[2]) == [64 125 216]
+            @test FeatureTransforms.apply(A, p; dims=2, inds=[2]) == reshape([8, 125], 2, 1)
         end
     end
 
@@ -75,21 +75,21 @@
         expected = KeyedArray([1 8 27; 64 125 216], foo=["a", "b"], bar=["x", "y", "z"])
 
         @testset "dims = $d" for d in (Colon(), :foo, :bar)
-            transformed = Transforms.apply(A, p; dims=d)
+            transformed = FeatureTransforms.apply(A, p; dims=d)
             @test transformed isa KeyedArray
             @test transformed == expected
         end
 
         _A = copy(A)
-        Transforms.apply!(_A, p)
+        FeatureTransforms.apply!(_A, p)
         @test _A isa KeyedArray
         @test _A == expected
 
         @testset "inds" begin
-            @test Transforms.apply(A, p; inds=[2, 3]) == [64, 8]
-            @test Transforms.apply(A, p; dims=:, inds=[2, 3]) == [64, 8]
-            @test Transforms.apply(A, p; dims=1, inds=[2]) == [64 125 216]
-            @test Transforms.apply(A, p; dims=2, inds=[2]) == reshape([8, 125], 2, 1)
+            @test FeatureTransforms.apply(A, p; inds=[2, 3]) == [64, 8]
+            @test FeatureTransforms.apply(A, p; dims=:, inds=[2, 3]) == [64, 8]
+            @test FeatureTransforms.apply(A, p; dims=1, inds=[2]) == [64 125 216]
+            @test FeatureTransforms.apply(A, p; dims=2, inds=[2]) == reshape([8, 125], 2, 1)
         end
     end
 
@@ -99,11 +99,11 @@
         expected_nt = (a = [1, 8, 27], b = [64, 125, 216])
 
         @testset "all cols" begin
-            @test Transforms.apply(nt, p) == expected
+            @test FeatureTransforms.apply(nt, p) == expected
             @test p(nt) == expected
 
             _nt = deepcopy(nt)
-            Transforms.apply!(_nt, p)
+            FeatureTransforms.apply!(_nt, p)
             @test _nt isa NamedTuple{(:a, :b)}
             @test _nt == expected_nt
         end
@@ -112,13 +112,13 @@
             nt_mutated = NamedTuple{(Symbol("$c"), )}((expected_nt[c], ))
             expected_nt_mutated = merge(nt, nt_mutated)
 
-            @test Transforms.apply(nt, p; cols=[c]) == [expected_nt[c]]
-            @test Transforms.apply(nt, p; cols=c) == expected_nt[c]
+            @test FeatureTransforms.apply(nt, p; cols=[c]) == [expected_nt[c]]
+            @test FeatureTransforms.apply(nt, p; cols=c) == expected_nt[c]
             @test p(nt; cols=[c]) == [expected_nt[c]]
 
             @testset "mutating" for _c in (c, [c])
                 _nt = deepcopy(nt)
-                Transforms.apply!(_nt, p; cols=_c)
+                FeatureTransforms.apply!(_nt, p; cols=_c)
                 @test _nt == expected_nt_mutated
                 @test _nt isa NamedTuple
             end
@@ -131,18 +131,18 @@
         expected = [expected_df.a, expected_df.b]
 
         @testset "all cols" begin
-            @test Transforms.apply(df, p) == expected
+            @test FeatureTransforms.apply(df, p) == expected
             @test p(df) == expected
 
             _df = deepcopy(df)
-            Transforms.apply!(_df, p)
+            FeatureTransforms.apply!(_df, p)
             @test _df isa DataFrame
             @test _df == expected_df
         end
 
         @testset "cols = $c" for c in (:a, :b)
-            @test Transforms.apply(df, p; cols=[c]) == [expected_df[!, c]]
-            @test Transforms.apply(df, p; cols=c) == expected_df[!, c]
+            @test FeatureTransforms.apply(df, p; cols=[c]) == [expected_df[!, c]]
+            @test FeatureTransforms.apply(df, p; cols=c) == expected_df[!, c]
             @test p(df; cols=[c]) == [expected_df[!, c]]
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,12 +2,12 @@ using AxisArrays
 using AxisKeys
 using DataFrames: DataFrame
 using Dates
-using Transforms
-using Transforms: _try_copy, _periodic
+using FeatureTransforms
+using FeatureTransforms: _try_copy, _periodic
 using Test
 using TimeZones
 
-@testset "Transforms.jl" begin
+@testset "FeatureTransforms.jl" begin
     include("linear_combination.jl")
     include("one_hot_encoding.jl")
     include("periodic.jl")

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -8,28 +8,28 @@
             x = [1., 2., 3.]
             expected = [1., 2., 3.]
 
-            @test Transforms.apply(x, scaling) == expected
+            @test FeatureTransforms.apply(x, scaling) == expected
             @test scaling(x) == expected
 
             @testset "Mutating" begin
                 _x = copy(x)
-                Transforms.apply!(_x, scaling)
+                FeatureTransforms.apply!(_x, scaling)
                 @test _x == expected
             end
 
             @testset "dims" begin
-                @test Transforms.apply(x, scaling; dims=1) == expected
-                @test_throws BoundsError Transforms.apply(expected, scaling; dims=2)
+                @test FeatureTransforms.apply(x, scaling; dims=1) == expected
+                @test_throws BoundsError FeatureTransforms.apply(expected, scaling; dims=2)
             end
 
             @testset "inds" begin
-                @test Transforms.apply(x, scaling; inds=[2, 3]) == [2., 3.]
-                @test Transforms.apply(x, scaling; dims=:, inds=[2, 3]) == [2., 3.]
-                @test Transforms.apply(x, scaling; dims=1, inds=[2, 3]) == [2., 3.]
+                @test FeatureTransforms.apply(x, scaling; inds=[2, 3]) == [2., 3.]
+                @test FeatureTransforms.apply(x, scaling; dims=:, inds=[2, 3]) == [2., 3.]
+                @test FeatureTransforms.apply(x, scaling; dims=1, inds=[2, 3]) == [2., 3.]
             end
 
             @testset "Inverse" begin
-                @test Transforms.apply(x, scaling; inverse=true) == expected
+                @test FeatureTransforms.apply(x, scaling; inverse=true) == expected
             end
         end
 
@@ -37,27 +37,27 @@
             M = [0.0 -0.5 0.5; 0.0 1.0 2.0]
             M_expected = [0.0 -0.5 0.5; 0.0 1.0 2.0]
 
-           @test Transforms.apply(M, scaling) == M_expected
+           @test FeatureTransforms.apply(M, scaling) == M_expected
 
             @testset "Mutating" begin
                 _M = copy(M)
-                Transforms.apply!(_M, scaling)
+                FeatureTransforms.apply!(_M, scaling)
                 @test _M == M_expected
             end
 
             @testset "dims = $d" for d in (Colon(), 1, 2)
-                @test Transforms.apply(M, scaling; dims=d) == M_expected
+                @test FeatureTransforms.apply(M, scaling; dims=d) == M_expected
             end
 
             @testset "inds" begin
-                @test Transforms.apply(M, scaling; inds=[2, 3]) == [0.0, -0.5]
-                @test Transforms.apply(M, scaling; dims=:, inds=[2, 3]) == [0.0, -0.5]
-                @test Transforms.apply(M, scaling; dims=1, inds=[2]) == [0.0 1.0 2.0]
-                @test Transforms.apply(M, scaling; dims=2, inds=[2]) == reshape([-0.5; 1.0], 2, 1)
+                @test FeatureTransforms.apply(M, scaling; inds=[2, 3]) == [0.0, -0.5]
+                @test FeatureTransforms.apply(M, scaling; dims=:, inds=[2, 3]) == [0.0, -0.5]
+                @test FeatureTransforms.apply(M, scaling; dims=1, inds=[2]) == [0.0 1.0 2.0]
+                @test FeatureTransforms.apply(M, scaling; dims=2, inds=[2]) == reshape([-0.5; 1.0], 2, 1)
             end
 
             @testset "Inverse" begin
-                @test Transforms.apply(M, scaling; inverse=true) == M_expected
+                @test FeatureTransforms.apply(M, scaling; inverse=true) == M_expected
             end
         end
 
@@ -67,28 +67,28 @@
             M_expected = [0.0 -0.5 0.5; 0.0 1.0 2.0]
             A_expected = AxisArray(M_expected; foo=["a", "b"], bar=["x", "y", "z"])
 
-            @test Transforms.apply(A, scaling) == A_expected
+            @test FeatureTransforms.apply(A, scaling) == A_expected
 
             @testset "Mutating" begin
                 _A = copy(A)
-                Transforms.apply!(_A, scaling)
+                FeatureTransforms.apply!(_A, scaling)
                 @test _A isa AxisArray
                 @test _A == A_expected
             end
 
             @testset "dims = $d" for d in (Colon(), 1, 2)
-                @test Transforms.apply(M, scaling; dims=d) == A_expected
+                @test FeatureTransforms.apply(M, scaling; dims=d) == A_expected
             end
 
             @testset "inds" begin
-                @test Transforms.apply(A, scaling; inds=[2, 3]) == [0.0, -0.5]
-                @test Transforms.apply(A, scaling; dims=:, inds=[2, 3]) == [0.0, -0.5]
-                @test Transforms.apply(A, scaling; dims=1, inds=[2]) == [0.0 1.0 2.0]
-                @test Transforms.apply(A, scaling; dims=2, inds=[2]) == reshape([-0.5; 1.0], 2, 1)
+                @test FeatureTransforms.apply(A, scaling; inds=[2, 3]) == [0.0, -0.5]
+                @test FeatureTransforms.apply(A, scaling; dims=:, inds=[2, 3]) == [0.0, -0.5]
+                @test FeatureTransforms.apply(A, scaling; dims=1, inds=[2]) == [0.0 1.0 2.0]
+                @test FeatureTransforms.apply(A, scaling; dims=2, inds=[2]) == reshape([-0.5; 1.0], 2, 1)
             end
 
             @testset "Inverse" begin
-                @test Transforms.apply(A, scaling; inverse=true) == A_expected
+                @test FeatureTransforms.apply(A, scaling; inverse=true) == A_expected
             end
         end
 
@@ -98,28 +98,28 @@
             M_expected = [0.0 -0.5 0.5; 0.0 1.0 2.0]
             A_expected = KeyedArray(M_expected; foo=["a", "b"], bar=["x", "y", "z"])
 
-            @test Transforms.apply(A, scaling) == A_expected
+            @test FeatureTransforms.apply(A, scaling) == A_expected
 
             @testset "Mutating" begin
                 _A = copy(A)
-                Transforms.apply!(_A, scaling)
+                FeatureTransforms.apply!(_A, scaling)
                 @test _A isa KeyedArray
                 @test _A == A_expected
             end
 
             @testset "dims = $d" for d in (Colon(), 1, 2)
-                @test Transforms.apply(M, scaling; dims=d) == A_expected
+                @test FeatureTransforms.apply(M, scaling; dims=d) == A_expected
             end
 
             @testset "inds" begin
-                @test Transforms.apply(A, scaling; inds=[2, 3]) == [0.0, -0.5]
-                @test Transforms.apply(A, scaling; dims=:, inds=[2, 3]) == [0.0, -0.5]
-                @test Transforms.apply(A, scaling; dims=1, inds=[2]) == [0.0 1.0 2.0]
-                @test Transforms.apply(A, scaling; dims=2, inds=[2]) == reshape([-0.5; 1.0], 2, 1)
+                @test FeatureTransforms.apply(A, scaling; inds=[2, 3]) == [0.0, -0.5]
+                @test FeatureTransforms.apply(A, scaling; dims=:, inds=[2, 3]) == [0.0, -0.5]
+                @test FeatureTransforms.apply(A, scaling; dims=1, inds=[2]) == [0.0 1.0 2.0]
+                @test FeatureTransforms.apply(A, scaling; dims=2, inds=[2]) == reshape([-0.5; 1.0], 2, 1)
             end
 
             @testset "Inverse" begin
-                @test Transforms.apply(A, scaling; inverse=true) == A_expected
+                @test FeatureTransforms.apply(A, scaling; inverse=true) == A_expected
             end
         end
 
@@ -127,22 +127,22 @@
             nt = (a = [0.0, -0.5, 0.5], b = [1.0, 0.0, 2.0])
             nt_expected = (a = [0.0, -0.5, 0.5], b = [1.0, 0.0, 2.0])
 
-           @test Transforms.apply(nt, scaling) == [nt_expected.a, nt_expected.b]
+           @test FeatureTransforms.apply(nt, scaling) == [nt_expected.a, nt_expected.b]
 
             @testset "Mutating" begin
                 _nt = deepcopy(nt)
-                Transforms.apply!(_nt, scaling)
+                FeatureTransforms.apply!(_nt, scaling)
                 @test _nt isa NamedTuple{(:a, :b)}
                 @test _nt == nt_expected
             end
 
             @testset "cols = $c" for c in (:a, :b)
-                @test Transforms.apply(nt, scaling; cols=[c]) ≈ [nt_expected[c]]
-                @test Transforms.apply(nt, scaling; cols=c) ≈ nt_expected[c]
+                @test FeatureTransforms.apply(nt, scaling; cols=[c]) ≈ [nt_expected[c]]
+                @test FeatureTransforms.apply(nt, scaling; cols=c) ≈ nt_expected[c]
             end
 
             @testset "Inverse" begin
-                @test Transforms.apply(nt, scaling; inverse=true) == [nt_expected.a, nt_expected.b]
+                @test FeatureTransforms.apply(nt, scaling; inverse=true) == [nt_expected.a, nt_expected.b]
             end
         end
 
@@ -150,22 +150,22 @@
             df = DataFrame(:a => [0.0, -0.5, 0.5], :b => [1.0, 0.0, 2.0])
             df_expected = DataFrame(:a => [0.0, -0.5, 0.5], :b => [1.0, 0.0, 2.0])
 
-            @test Transforms.apply(df, scaling) == [df_expected.a, df_expected.b]
+            @test FeatureTransforms.apply(df, scaling) == [df_expected.a, df_expected.b]
 
             @testset "Mutating" begin
                 _df = deepcopy(df)
-                Transforms.apply!(_df, scaling)
+                FeatureTransforms.apply!(_df, scaling)
                 @test _df isa DataFrame
                 @test _df == df_expected
             end
 
             @testset "cols = $c" for c in (:a, :b)
-                @test Transforms.apply(df, scaling; cols=[c]) ≈ [df_expected[!, c]]
-                @test Transforms.apply(df, scaling; cols=c) ≈ df_expected[!, c]
+                @test FeatureTransforms.apply(df, scaling; cols=[c]) ≈ [df_expected[!, c]]
+                @test FeatureTransforms.apply(df, scaling; cols=c) ≈ df_expected[!, c]
             end
 
             @testset "Inverse" begin
-                @test Transforms.apply(df, scaling; inverse=true) == [df_expected.a, df_expected.b]
+                @test FeatureTransforms.apply(df, scaling; inverse=true) == [df_expected.a, df_expected.b]
             end
         end
     end
@@ -191,7 +191,7 @@
                 @test scaling.mean == (all=1., )
                 @test scaling.std == (all=2., )
 
-                @test Transforms.apply(x, scaling) == expected
+                @test FeatureTransforms.apply(x, scaling) == expected
             end
         end
 
@@ -201,7 +201,7 @@
 
             @testset "Non-mutating" begin
                 scaling = MeanStdScaling(x)
-                @test Transforms.apply(x, scaling) ≈ expected atol=1e-5
+                @test FeatureTransforms.apply(x, scaling) ≈ expected atol=1e-5
                 @test scaling(x) ≈ expected atol=1e-5
 
                 # Test the transform was not mutating
@@ -211,39 +211,39 @@
             @testset "Mutating" begin
                 scaling = MeanStdScaling(x)
                 _x = copy(x)
-                Transforms.apply!(_x, scaling)
+                FeatureTransforms.apply!(_x, scaling)
                 @test _x ≈ expected atol=1e-5
             end
 
             @testset "dims" begin
                 scaling = MeanStdScaling(x; dims=1)
-                @test Transforms.apply(x, scaling; dims=1) == expected
-                @test_throws BoundsError Transforms.apply(x, scaling; dims=2)
+                @test FeatureTransforms.apply(x, scaling; dims=1) == expected
+                @test_throws BoundsError FeatureTransforms.apply(x, scaling; dims=2)
             end
 
             @testset "inds" begin
                 scaling = MeanStdScaling(x)
-                @test Transforms.apply(x, scaling; inds=[2, 3]) == [0., 1.]
-                @test Transforms.apply(x, scaling; dims=:, inds=[2, 3]) == [0., 1.]
+                @test FeatureTransforms.apply(x, scaling; inds=[2, 3]) == [0., 1.]
+                @test FeatureTransforms.apply(x, scaling; dims=:, inds=[2, 3]) == [0., 1.]
 
                 scaling = MeanStdScaling(x; dims=1)
-                @test Transforms.apply(x, scaling; dims=1, inds=[2, 3]) == [0., 1.]
+                @test FeatureTransforms.apply(x, scaling; dims=1, inds=[2, 3]) == [0., 1.]
             end
 
             @testset "Re-apply" begin
                 scaling = MeanStdScaling(x)
-                Transforms.apply(x, scaling)
+                FeatureTransforms.apply(x, scaling)
 
                 # Expect scaling parameters to be fixed to the first data applied to
-                @test Transforms.apply([-0.5, 0.5, 0.0], scaling) ≈ [-2.5, -1.5, -2.0] atol=1e-5
+                @test FeatureTransforms.apply([-0.5, 0.5, 0.0], scaling) ≈ [-2.5, -1.5, -2.0] atol=1e-5
             end
 
             @testset "Inverse" begin
                 scaling = MeanStdScaling(x)
-                transformed = Transforms.apply(x, scaling)
+                transformed = FeatureTransforms.apply(x, scaling)
 
                 @test transformed ≈ expected atol=1e-5
-                @test Transforms.apply(transformed, scaling; inverse=true) ≈ x atol=1e-5
+                @test FeatureTransforms.apply(transformed, scaling; inverse=true) ≈ x atol=1e-5
             end
         end
 
@@ -253,7 +253,7 @@
 
             @testset "Non-mutating" begin
                 scaling = MeanStdScaling(M)
-                @test Transforms.apply(M, scaling) ≈ M_expected atol=1e-5
+                @test FeatureTransforms.apply(M, scaling) ≈ M_expected atol=1e-5
                 @test scaling(M) ≈ M_expected atol=1e-5
 
                 # Test the transform was not mutating
@@ -263,51 +263,51 @@
             @testset "Mutating" begin
                 scaling = MeanStdScaling(M)
                 _M = copy(M)
-                Transforms.apply!(_M, scaling)
+                FeatureTransforms.apply!(_M, scaling)
                 @test _M ≈ M_expected atol=1e-5
             end
 
             @testset "dims = :" begin
                 scaling = MeanStdScaling(M; dims=:)
-                @test Transforms.apply(M, scaling; dims=:) ≈ M_expected atol=1e-5
+                @test FeatureTransforms.apply(M, scaling; dims=:) ≈ M_expected atol=1e-5
             end
 
             @testset "dims = 1" begin
                 scaling = MeanStdScaling(M; dims=1)
-                @test Transforms.apply(M, scaling; dims=1) ≈ [0.0 -0.707107 -0.707107; 0.0 0.707107 0.707107] atol=1e-5
+                @test FeatureTransforms.apply(M, scaling; dims=1) ≈ [0.0 -0.707107 -0.707107; 0.0 0.707107 0.707107] atol=1e-5
             end
 
             @testset "dims = 2" begin
                 scaling = MeanStdScaling(M; dims=2)
-                @test Transforms.apply(M, scaling; dims=2) ≈ [0.0 -1.0 1.0; -1.0 0.0 1.0] atol=1e-5
+                @test FeatureTransforms.apply(M, scaling; dims=2) ≈ [0.0 -1.0 1.0; -1.0 0.0 1.0] atol=1e-5
             end
 
             @testset "inds" begin
                 scaling = MeanStdScaling(M)
-                @test Transforms.apply(M, scaling; inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
-                @test Transforms.apply(M, scaling; dims=:, inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
+                @test FeatureTransforms.apply(M, scaling; inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
+                @test FeatureTransforms.apply(M, scaling; dims=:, inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
 
                 scaling = MeanStdScaling(M; dims=1)
-                @test Transforms.apply(M, scaling; dims=1, inds=[2]) ≈ [0.0 0.707107 0.707107] atol=1e-5
+                @test FeatureTransforms.apply(M, scaling; dims=1, inds=[2]) ≈ [0.0 0.707107 0.707107] atol=1e-5
 
                 scaling = MeanStdScaling(M; dims=2)
-                @test Transforms.apply(M, scaling; dims=2, inds=[2]) ≈ [-1.0 0.0]' atol=1e-5
+                @test FeatureTransforms.apply(M, scaling; dims=2, inds=[2]) ≈ [-1.0 0.0]' atol=1e-5
             end
 
             @testset "Re-apply" begin
                 scaling = MeanStdScaling(M; dims=2)
-                Transforms.apply(M, scaling; dims=2)
+                FeatureTransforms.apply(M, scaling; dims=2)
 
                 # Expect scaling parameters to be fixed to the first data applied to
-                @test Transforms.apply([1.0 -2.0 -1.0; 0.5 0.0 0.5], scaling; dims=2) ≈ [2.0 -4.0 -2.0; -0.5 -1.0 -0.5] atol=1e-5
+                @test FeatureTransforms.apply([1.0 -2.0 -1.0; 0.5 0.0 0.5], scaling; dims=2) ≈ [2.0 -4.0 -2.0; -0.5 -1.0 -0.5] atol=1e-5
             end
 
             @testset "Inverse" begin
                 scaling = MeanStdScaling(M)
-                transformed = Transforms.apply(M, scaling)
+                transformed = FeatureTransforms.apply(M, scaling)
 
                 @test transformed ≈ M_expected atol=1e-5
-                @test Transforms.apply(transformed, scaling; inverse=true) ≈ M atol=1e-5
+                @test FeatureTransforms.apply(transformed, scaling; inverse=true) ≈ M atol=1e-5
             end
         end
 
@@ -319,7 +319,7 @@
 
             @testset "Non-mutating" begin
                 scaling = MeanStdScaling(A)
-                @test Transforms.apply(A, scaling) ≈ A_expected atol=1e-5
+                @test FeatureTransforms.apply(A, scaling) ≈ A_expected atol=1e-5
                 @test scaling(A) ≈ A_expected atol=1e-5
 
                 # Test the transform was not mutating
@@ -329,52 +329,52 @@
             @testset "Mutating" begin
                 scaling = MeanStdScaling(A)
                 _A = copy(A)
-                Transforms.apply!(_A, scaling)
+                FeatureTransforms.apply!(_A, scaling)
                 @test _A isa AxisArray
                 @test _A ≈ A_expected atol=1e-5
             end
 
             @testset "dims = :" begin
                 scaling = MeanStdScaling(A)
-                @test Transforms.apply(A, scaling; dims=:) ≈ A_expected atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=:) ≈ A_expected atol=1e-5
             end
 
             @testset "dims = 1" begin
                 scaling = MeanStdScaling(A; dims=1)
-                @test Transforms.apply(A, scaling; dims=1) ≈ [0.0 -0.707107 -0.707107; 0.0 0.707107 0.707107] atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=1) ≈ [0.0 -0.707107 -0.707107; 0.0 0.707107 0.707107] atol=1e-5
             end
 
             @testset "dims = 2" begin
                 scaling = MeanStdScaling(A; dims=2)
-                @test Transforms.apply(A, scaling; dims=2) ≈ [0.0 -1.0 1.0; -1.0 0.0 1.0] atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=2) ≈ [0.0 -1.0 1.0; -1.0 0.0 1.0] atol=1e-5
             end
 
             @testset "inds" begin
                 scaling = MeanStdScaling(A)
-                @test Transforms.apply(A, scaling; inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
-                @test Transforms.apply(A, scaling; dims=:, inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=:, inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
 
                 scaling = MeanStdScaling(A; dims=1)
-                @test Transforms.apply(A, scaling; dims=1, inds=[2]) ≈ [0.0 0.707107 0.707107] atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=1, inds=[2]) ≈ [0.0 0.707107 0.707107] atol=1e-5
 
                 scaling = MeanStdScaling(A; dims=2)
-                @test Transforms.apply(A, scaling; dims=2, inds=[2]) ≈ [-1.0 0.0]' atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=2, inds=[2]) ≈ [-1.0 0.0]' atol=1e-5
             end
 
             @testset "Re-apply" begin
                 scaling = MeanStdScaling(A; dims=2)
-                Transforms.apply(A, scaling; dims=2)
+                FeatureTransforms.apply(A, scaling; dims=2)
 
                 # Expect scaling parameters to be fixed to the first data applied to
-                @test Transforms.apply([1.0 -2.0 -1.0; 0.5 0.0 0.5], scaling; dims=2) ≈ [2.0 -4.0 -2.0; -0.5 -1.0 -0.5] atol=1e-5
+                @test FeatureTransforms.apply([1.0 -2.0 -1.0; 0.5 0.0 0.5], scaling; dims=2) ≈ [2.0 -4.0 -2.0; -0.5 -1.0 -0.5] atol=1e-5
             end
 
             @testset "Inverse" begin
                 scaling = MeanStdScaling(A)
-                transformed = Transforms.apply(A, scaling)
+                transformed = FeatureTransforms.apply(A, scaling)
 
                 @test transformed ≈ A_expected atol=1e-5
-                @test Transforms.apply(transformed, scaling; inverse=true) ≈ A atol=1e-5
+                @test FeatureTransforms.apply(transformed, scaling; inverse=true) ≈ A atol=1e-5
             end
         end
 
@@ -386,7 +386,7 @@
 
             @testset "Non-mutating" begin
                 scaling = MeanStdScaling(A)
-                @test Transforms.apply(A, scaling) ≈ A_expected atol=1e-5
+                @test FeatureTransforms.apply(A, scaling) ≈ A_expected atol=1e-5
                 @test scaling(A) ≈ A_expected atol=1e-5
 
                 # Test the transform was not mutating
@@ -396,52 +396,52 @@
             @testset "Mutating" begin
                 scaling = MeanStdScaling(A)
                 _A = copy(A)
-                Transforms.apply!(_A, scaling)
+                FeatureTransforms.apply!(_A, scaling)
                 @test _A isa KeyedArray
                 @test _A ≈ A_expected atol=1e-5
             end
 
             @testset "dims = :" begin
                 scaling = MeanStdScaling(A)
-                @test Transforms.apply(A, scaling; dims=:) ≈ A_expected atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=:) ≈ A_expected atol=1e-5
             end
 
             @testset "dims = 1" begin
                 scaling = MeanStdScaling(A; dims=1)
-                @test Transforms.apply(A, scaling; dims=1) ≈ [0.0 -0.707107 -0.707107; 0.0 0.707107 0.707107] atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=1) ≈ [0.0 -0.707107 -0.707107; 0.0 0.707107 0.707107] atol=1e-5
             end
 
             @testset "dims = 2" begin
                 scaling = MeanStdScaling(A; dims=2)
-                @test Transforms.apply(A, scaling; dims=2) ≈ [0.0 -1.0 1.0; -1.0 0.0 1.0] atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=2) ≈ [0.0 -1.0 1.0; -1.0 0.0 1.0] atol=1e-5
             end
 
             @testset "inds" begin
                 scaling = MeanStdScaling(A)
-                @test Transforms.apply(A, scaling; inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
-                @test Transforms.apply(A, scaling; dims=:, inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=:, inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
 
                 scaling = MeanStdScaling(A; dims=1)
-                @test Transforms.apply(A, scaling; dims=1, inds=[2]) ≈ [0.0 0.707107 0.707107] atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=1, inds=[2]) ≈ [0.0 0.707107 0.707107] atol=1e-5
 
                 scaling = MeanStdScaling(A; dims=2)
-                @test Transforms.apply(A, scaling; dims=2, inds=[2]) ≈ [-1.0 0.0]' atol=1e-5
+                @test FeatureTransforms.apply(A, scaling; dims=2, inds=[2]) ≈ [-1.0 0.0]' atol=1e-5
             end
 
             @testset "Re-apply" begin
                 scaling = MeanStdScaling(A; dims=2)
-                Transforms.apply(A, scaling; dims=2)
+                FeatureTransforms.apply(A, scaling; dims=2)
 
                 # Expect scaling parameters to be fixed to the first data applied to
-                @test Transforms.apply([1.0 -2.0 -1.0; 0.5 0.0 0.5], scaling; dims=2) ≈ [2.0 -4.0 -2.0; -0.5 -1.0 -0.5] atol=1e-5
+                @test FeatureTransforms.apply([1.0 -2.0 -1.0; 0.5 0.0 0.5], scaling; dims=2) ≈ [2.0 -4.0 -2.0; -0.5 -1.0 -0.5] atol=1e-5
             end
 
             @testset "Inverse" begin
                 scaling = MeanStdScaling(A)
-                transformed = Transforms.apply(A, scaling)
+                transformed = FeatureTransforms.apply(A, scaling)
 
                 @test transformed ≈ A_expected atol=1e-5
-                @test Transforms.apply(transformed, scaling; inverse=true) ≈ A atol=1e-5
+                @test FeatureTransforms.apply(transformed, scaling; inverse=true) ≈ A atol=1e-5
             end
         end
 
@@ -451,14 +451,14 @@
 
             @testset "Non-mutating" begin
                 scaling = MeanStdScaling(nt)
-                @test Transforms.apply(nt, scaling) ≈ [nt_expected.a, nt_expected.b] atol=1e-5
+                @test FeatureTransforms.apply(nt, scaling) ≈ [nt_expected.a, nt_expected.b] atol=1e-5
                 @test scaling(nt) ≈ [nt_expected.a, nt_expected.b] atol=1e-5
             end
 
             @testset "Mutating" begin
                 scaling = MeanStdScaling(nt)
                 _nt = deepcopy(nt)
-                Transforms.apply!(_nt, scaling)
+                FeatureTransforms.apply!(_nt, scaling)
                 @test _nt isa NamedTuple{(:a, :b)}
                 @test collect(_nt) ≈ collect(nt_expected) atol=1e-5
             end
@@ -468,33 +468,33 @@
                 nt_mutated = NamedTuple{(Symbol("$c"), )}((nt_expected[c], ))
                 nt_expected_ = merge(nt, nt_mutated)
 
-                @test Transforms.apply(nt, scaling; cols=[c]) ≈ [collect(nt_expected_[c])] atol=1e-14
-                @test Transforms.apply(nt, scaling; cols=c) ≈ collect(nt_expected_[c]) atol=1e-14
+                @test FeatureTransforms.apply(nt, scaling; cols=[c]) ≈ [collect(nt_expected_[c])] atol=1e-14
+                @test FeatureTransforms.apply(nt, scaling; cols=c) ≈ collect(nt_expected_[c]) atol=1e-14
                 @test scaling(nt; cols=[c]) ≈ [collect(nt_expected_[c])] atol=1e-14
 
                 _nt = deepcopy(nt)
-                Transforms.apply!(_nt, scaling; cols=[c])
+                FeatureTransforms.apply!(_nt, scaling; cols=[c])
                 @test _nt isa NamedTuple{(:a, :b)}  # before applying `collect`
                 @test collect(_nt) ≈ collect(nt_expected_) atol=1e-14
             end
 
             @testset "Re-apply" begin
                 scaling = MeanStdScaling(nt)
-                Transforms.apply(nt, scaling)
+                FeatureTransforms.apply(nt, scaling)
 
                 # Expect scaling parameters to be fixed to the first data applied to
                 nt2 = (a = [-1.0, 0.5, 0.0], b = [2.0, 2.0, 1.0])
                 nt_expected2 = (a = [-2.0, 1.0, 0.0], b = [1.0, 1.0, 0.0])
-                @test Transforms.apply(nt2, scaling) ≈ [nt_expected2.a, nt_expected2.b] atol=1e-5
+                @test FeatureTransforms.apply(nt2, scaling) ≈ [nt_expected2.a, nt_expected2.b] atol=1e-5
             end
 
             @testset "Inverse" begin
                 scaling = MeanStdScaling(nt)
-                transformed = Transforms.apply(nt, scaling)
+                transformed = FeatureTransforms.apply(nt, scaling)
                 transformed = (a = transformed[1], b = transformed[2])
 
                 @test collect(transformed) ≈ collect(nt_expected) atol=1e-5
-                @test Transforms.apply(transformed, scaling; inverse=true) ≈ [nt.a, nt.b] atol=1e-5
+                @test FeatureTransforms.apply(transformed, scaling; inverse=true) ≈ [nt.a, nt.b] atol=1e-5
             end
         end
 
@@ -504,7 +504,7 @@
 
             @testset "Non-mutating" begin
                 scaling = MeanStdScaling(df)
-                transformed = Transforms.apply(df, scaling)
+                transformed = FeatureTransforms.apply(df, scaling)
                 @test transformed ≈ [df_expected.a, df_expected.b] atol=1e-5
                 @test scaling(df) ≈ [df_expected.a, df_expected.b] atol=1e-5
             end
@@ -512,7 +512,7 @@
             @testset "Mutating" begin
                 scaling = MeanStdScaling(df)
                 _df = deepcopy(df)
-                Transforms.apply!(_df, scaling)
+                FeatureTransforms.apply!(_df, scaling)
                 @test _df isa DataFrame
                 @test _df ≈ df_expected atol=1e-5
             end
@@ -520,34 +520,34 @@
             @testset "cols = $c" for c in (:a, :b)
                 scaling = MeanStdScaling(df; cols=[c])
 
-                @test Transforms.apply(df, scaling; cols=[c]) ≈ [df_expected[!, c]] atol=1e-5
-                @test Transforms.apply(df, scaling; cols=c) ≈ df_expected[!, c] atol=1e-5
+                @test FeatureTransforms.apply(df, scaling; cols=[c]) ≈ [df_expected[!, c]] atol=1e-5
+                @test FeatureTransforms.apply(df, scaling; cols=c) ≈ df_expected[!, c] atol=1e-5
 
                 _df = deepcopy(df)
                 _df_expected = deepcopy(df)
                 _df_expected[!, c] = df_expected[!, c]
-                Transforms.apply!(_df, scaling; cols=[c])
+                FeatureTransforms.apply!(_df, scaling; cols=[c])
                 @test _df isa DataFrame
                 @test _df ≈ _df_expected atol=1e-5
             end
 
             @testset "Re-apply" begin
                 scaling = MeanStdScaling(df)
-                Transforms.apply(df, scaling)
+                FeatureTransforms.apply(df, scaling)
 
                 # Expect scaling parameters to be fixed to the first data applied to
                 df2 = DataFrame(:a => [-1.0, 0.5, 0.0], :b => [2.0, 2.0, 1.0])
                 df_expected2 = DataFrame(:a => [-2.0, 1.0, 0.0], :b => [1.0, 1.0, 0.0])
-                @test Transforms.apply(df2, scaling) ≈ [df_expected2.a, df_expected2.b] atol=1e-5
+                @test FeatureTransforms.apply(df2, scaling) ≈ [df_expected2.a, df_expected2.b] atol=1e-5
             end
 
             @testset "Inverse" begin
                 scaling = MeanStdScaling(df)
-                transformed = Transforms.apply(df, scaling)
+                transformed = FeatureTransforms.apply(df, scaling)
                 transformed = DataFrame(:a => transformed[1], :b => transformed[2])
 
                 @test transformed ≈ df_expected atol=1e-5
-                @test Transforms.apply(transformed, scaling; inverse=true) ≈ [df.a, df.b] atol=1e-5
+                @test FeatureTransforms.apply(transformed, scaling; inverse=true) ≈ [df.a, df.b] atol=1e-5
             end
         end
 
@@ -557,9 +557,9 @@
 
             scaling = MeanStdScaling(x)
 
-            @test Transforms.apply(x, scaling) == expected  # default `eps`
-            @test Transforms.apply(x, scaling; eps=1) == expected
-            @test all(isnan.(Transforms.apply(x, scaling; eps=0)))  # 0/0
+            @test FeatureTransforms.apply(x, scaling) == expected  # default `eps`
+            @test FeatureTransforms.apply(x, scaling; eps=1) == expected
+            @test all(isnan.(FeatureTransforms.apply(x, scaling; eps=0)))  # 0/0
         end
     end
 end

--- a/test/temporal.jl
+++ b/test/temporal.jl
@@ -9,7 +9,7 @@
         # with 126 full days in the middle
         expected = [9:23..., repeat(0:23, 126)..., 0:9...]
 
-        @test Transforms.apply(x, hod) == expected
+        @test FeatureTransforms.apply(x, hod) == expected
         @test hod(x) == expected
 
         # Test the tranform was not mutating
@@ -17,22 +17,22 @@
 
         @testset "StepRange" begin
             x = DateTime(2020, 1, 1, 9, 0):Hour(1):DateTime(2020, 5, 7, 9, 0)
-            @test Transforms.apply(x, hod) == expected
+            @test FeatureTransforms.apply(x, hod) == expected
             @test hod(x) == expected
         end
 
         @testset "dims = $d" for d in (Colon(), 1)
-            @test Transforms.apply(x, hod; dims=d) == expected
+            @test FeatureTransforms.apply(x, hod; dims=d) == expected
             @test hod(x; dims=d) == expected
         end
 
-        @test_throws BoundsError Transforms.apply(x, hod; dims=2)
+        @test_throws BoundsError FeatureTransforms.apply(x, hod; dims=2)
 
         @testset "inds" begin
-            @test Transforms.apply(x, hod; inds=2:5) == expected[2:5]
-            @test Transforms.apply(x, hod; dims=:) == expected
-            @test Transforms.apply(x, hod; dims=1) == expected
-            @test Transforms.apply(x, hod; dims=1, inds=[2, 3, 4, 5]) == expected[2:5]
+            @test FeatureTransforms.apply(x, hod; inds=2:5) == expected[2:5]
+            @test FeatureTransforms.apply(x, hod; dims=:) == expected
+            @test FeatureTransforms.apply(x, hod; dims=1) == expected
+            @test FeatureTransforms.apply(x, hod; dims=1, inds=[2, 3, 4, 5]) == expected[2:5]
         end
 
         @testset "DST" begin
@@ -41,7 +41,7 @@
             # expected result skips the DST transition hour of 2
             expected_dst = [9:23..., 0, 1, 3:9...]
 
-            @test Transforms.apply(x, hod) == expected_dst
+            @test FeatureTransforms.apply(x, hod) == expected_dst
             @test hod(x) == expected_dst
         end
     end
@@ -54,22 +54,22 @@
         M = reshape(x, 3, 2)
         expected = [1 9; 2 10; 3 11]
 
-        @test Transforms.apply(M, hod) == expected
+        @test FeatureTransforms.apply(M, hod) == expected
         @test hod(M) == expected
 
         # Test the tranform was not mutating
         @test M != expected
 
         @testset "dims = $d" for d in (Colon(), 1, 2)
-            @test Transforms.apply(M, hod; dims=d) == expected
+            @test FeatureTransforms.apply(M, hod; dims=d) == expected
             @test hod(M; dims=d) == expected
         end
 
         @testset "inds" begin
-            @test Transforms.apply(M, hod; inds=[2, 3]) == [2, 3]
-            @test Transforms.apply(M, hod; dims=:, inds=[2, 3]) == [2, 3]
-            @test Transforms.apply(M, hod; dims=1, inds=[2]) == [2 10]
-            @test Transforms.apply(M, hod; dims=2, inds=[2]) == reshape([9; 10; 11], 3, 1)
+            @test FeatureTransforms.apply(M, hod; inds=[2, 3]) == [2, 3]
+            @test FeatureTransforms.apply(M, hod; dims=:, inds=[2, 3]) == [2, 3]
+            @test FeatureTransforms.apply(M, hod; dims=1, inds=[2]) == [2 10]
+            @test FeatureTransforms.apply(M, hod; dims=2, inds=[2]) == reshape([9; 10; 11], 3, 1)
         end
     end
 
@@ -83,21 +83,21 @@
         A = AxisArray(M, foo=["a", "b"], bar=["x", "y", "z"])
         expected = [1 9 11; 2 10 12]
 
-        @test Transforms.apply(A, hod) == expected
+        @test FeatureTransforms.apply(A, hod) == expected
         @test hod(A) == expected
 
         @testset "dims = $d" for d in (Colon(), 1, 2)
-            transformed = Transforms.apply(A, hod; dims=d)
+            transformed = FeatureTransforms.apply(A, hod; dims=d)
             # AxisArray doesn't preserve the type it operates on
             @test transformed isa AbstractArray
             @test transformed == expected
         end
 
         @testset "inds" begin
-            @test Transforms.apply(A, hod; inds=[2, 3]) == [2, 9]
-            @test Transforms.apply(A, hod; dims=:, inds=[2, 3]) == [2, 9]
-            @test Transforms.apply(A, hod; dims=1, inds=[2]) == [2 10 12]
-            @test Transforms.apply(A, hod; dims=2, inds=[2]) == reshape([9, 10], 2, 1)
+            @test FeatureTransforms.apply(A, hod; inds=[2, 3]) == [2, 9]
+            @test FeatureTransforms.apply(A, hod; dims=:, inds=[2, 3]) == [2, 9]
+            @test FeatureTransforms.apply(A, hod; dims=1, inds=[2]) == [2 10 12]
+            @test FeatureTransforms.apply(A, hod; dims=2, inds=[2]) == reshape([9, 10], 2, 1)
         end
     end
 
@@ -111,20 +111,20 @@
         A = KeyedArray(M, foo=["a", "b"], bar=["x", "y", "z"])
         expected = [1 9 11; 2 10 12]
 
-        @test Transforms.apply(A, hod) == expected
+        @test FeatureTransforms.apply(A, hod) == expected
         @test hod(A) == expected
 
         @testset "dims = $d" for d in (Colon(), 1, 2)
-            transformed = Transforms.apply(A, hod; dims=d)
+            transformed = FeatureTransforms.apply(A, hod; dims=d)
             @test transformed isa KeyedArray
             @test transformed == expected
         end
 
         @testset "inds" begin
-            @test Transforms.apply(A, hod; inds=[2, 3]) == [2, 9]
-            @test Transforms.apply(A, hod; dims=:, inds=[2, 3]) == [2, 9]
-            @test Transforms.apply(A, hod; dims=1, inds=[2]) == [2 10 12]
-            @test Transforms.apply(A, hod; dims=2, inds=[2]) == reshape([9, 10], 2, 1)
+            @test FeatureTransforms.apply(A, hod; inds=[2, 3]) == [2, 9]
+            @test FeatureTransforms.apply(A, hod; dims=:, inds=[2, 3]) == [2, 9]
+            @test FeatureTransforms.apply(A, hod; dims=1, inds=[2]) == [2 10 12]
+            @test FeatureTransforms.apply(A, hod; dims=2, inds=[2]) == reshape([9, 10], 2, 1)
         end
     end
 
@@ -137,7 +137,7 @@
         expected = [[0, 1, 2], [3, 4, 5]]
 
         @testset "all cols" begin
-            @test Transforms.apply(nt, hod) == expected
+            @test FeatureTransforms.apply(nt, hod) == expected
             @test hod(nt) == expected
 
             # Test the tranform was not mutating
@@ -145,8 +145,8 @@
         end
 
         @testset "cols = $c" for c in (:a, :b)
-            @test Transforms.apply(nt, hod; cols=[c]) == [expected_nt[c]]
-            @test Transforms.apply(nt, hod; cols=c) == expected_nt[c]
+            @test FeatureTransforms.apply(nt, hod; cols=[c]) == [expected_nt[c]]
+            @test FeatureTransforms.apply(nt, hod; cols=c) == expected_nt[c]
             @test hod(nt; cols=[c]) == [expected_nt[c]]
         end
     end
@@ -161,15 +161,15 @@
         expected = [expected_df.a, expected_df.b]
 
         @testset "all cols" begin
-            @test Transforms.apply(df, hod) == expected
+            @test FeatureTransforms.apply(df, hod) == expected
             @test hod(df) == expected
 
             # Test the tranform was not mutating
             @test df != expected
         end
 
-        @test Transforms.apply(df, hod; cols=[:a]) == [expected_df.a]
-        @test Transforms.apply(df, hod; cols=:a) == expected_df.a
-        @test Transforms.apply(df, hod; cols=[:b]) ==[expected_df.b]
+        @test FeatureTransforms.apply(df, hod; cols=[:a]) == [expected_df.a]
+        @test FeatureTransforms.apply(df, hod; cols=:a) == expected_df.a
+        @test FeatureTransforms.apply(df, hod; cols=[:b]) ==[expected_df.b]
     end
 end


### PR DESCRIPTION
Following the discussion in https://github.com/JuliaRegistries/General/pull/30630#issuecomment-785852528

I opted for `FeatureTransforms.jl` to conceptually align the package name with the `Transform` type we've already implemented.