### PR TITLE
RFC: Implement appending apply function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,6 @@ authors = ["Invenia Technical Computing Corporation"]
 version = "0.2.3"
 
 [deps]
-AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ authors = ["Invenia Technical Computing Corporation"]
 version = "0.2.3"
 
 [deps]
+AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"

--- a/test/appending_apply.jl
+++ b/test/appending_apply.jl
@@ -1,0 +1,73 @@
+# TODO - add to appropriate files
+@testset "apply!!" begin
+
+    @testset "Arrays" begin
+
+        M = [1 2 3; 4 5 6; 7 8 9]
+
+        @testset "Power" begin
+            p = Power(3)
+
+            @testset "dims=1, inds=:" begin
+                @test FeatureTransforms.apply!!(M, p; dims=1) == vcat(M, M .^ 3)
+            end
+
+            @testset "dims=1, inds=1" begin
+                @test FeatureTransforms.apply!!(M, p; dims=1, inds=1) == vcat(M, [1 ,8, 27]')
+            end
+
+            @testset "dims=2, inds=:" begin
+                @test FeatureTransforms.apply!!(M, p; dims=2) == hcat(M, M .^ 3)
+            end
+
+            @testset "dims=2, inds=1" begin
+                @test FeatureTransforms.apply!!(M, p; dims=2, inds=1) == hcat(M, [1, 64, 343])
+            end
+
+        end
+
+        @testset "LinearCombination" begin
+            lc = LinearCombination([1, -1])
+
+            @testset "dims=1" begin
+                @test FeatureTransforms.apply!!(M, lc; dims=1, inds=[1, 2]) == vcat(M, [-3, -3, -3]')
+            end
+
+            @testset "dims=2" begin
+                @test FeatureTransforms.apply!!(M, lc; dims=2, inds=[1, 2]) == hcat(M, [-1, -1, -1])
+            end
+        end
+    end
+
+    @testset "Tables" begin
+
+        nt = (a=[1, 2, 3], b=[4, 5, 6], c=[7, 8, 9])
+
+        @testset "Power" begin
+            p = Power(3)
+
+            @testset "cols=:a" begin
+                result = FeatureTransforms.apply!!(nt, p; cols=:a, new_cols=:a3)
+                @test result == merge(nt, (a3=[1, 8, 27], ))
+            end
+
+            @testset "cols=[:a, :b]" begin
+                result = FeatureTransforms.apply!!(nt, p; cols=[:a, :b], new_cols=[:a3, :b3])
+                @test result == merge(nt, (a3=[1, 8, 27], b3=[64, 125, 216]))
+            end
+
+        end
+
+        @testset "LinearCombination" begin
+            lc = LinearCombination([1, -1])
+
+            @testset "cols=[:a, :b]" begin
+                result = FeatureTransforms.apply!!(nt, lc; cols=[:a, :b], new_cols=[:ab])
+                @test result == merge(nt, (ab=[-3, -3, -3],))
+            end
+        end
+
+    end
+
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Test
 using TimeZones
 
 @testset "FeatureTransforms.jl" begin
+    include("appending_apply.jl")  # TODO: break up
     include("linear_combination.jl")
     include("one_hot_encoding.jl")
     include("periodic.jl")


### PR DESCRIPTION
POC for #38 

A few things to note
* I don't like the idea of this being a separate transform. I think it would just create extra steps to do exactly what we're doing here.
* I'm not against naming the method `apply_and_append` (or similar). I chose `apply!!` because of its brevity and I think it can be regarded as a reasonable extension to `apply` and `apply!`. Points against is that it might be easy to confuse?
* Case in point, the `!!` syntax would imply that the input is mutated directly. Right now it isn't but we might be able to do this if we want (I would be in favour given the above).
* This doesn't (directly) solve the issue of type promotion. I think, given how `apply!` is going to be used it might make sense for it to be able to do that? (I'm not aware of any implicit understand behind `!`-functions that preclude doing this?)


```julia
julia> df = DataFrame(:a=>[1, 2, 3, 4, 5], :b=>[5, 4, 3, 2, 1]);

julia> p = Power(3);

julia> FeatureTransforms.apply!!(df, p; cols=[:a, :b], new_cols=[:a3, :b3])
5×4 DataFrame
 Row │ a      b      a3     b3    
     │ Int64  Int64  Int64  Int64 
─────┼────────────────────────────
   1 │     1      5      1    125
   2 │     2      4      8     64
   3 │     3      3     27     27
   4 │     4      2     64      8
   5 │     5      1    125      1

julia> M = reshape(1:9, 3, 3)
3×3 reshape(::UnitRange{Int64}, 3, 3) with eltype Int64:
 1  4  7
 2  5  8
 3  6  9

julia> FeatureTransforms.apply!!(M, p; dims=1, inds=1)
4×3 Array{Int64,2}:
 1   4    7
 2   5    8
 3   6    9
 1  64  343
```