### PR TITLE
Refactor scaling to only compute one mean and std

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureTransforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -83,9 +83,13 @@ We can use `MeanStdScaling` for that purpose.
 Note that we are mutating the data frame in-place using `apply!`, and the order of columns specified does not matter.
 
 ```jldoctest example
-julia> scaling = MeanStdScaling(train_df; cols=output_cols);
+julia> temp_scaling = MeanStdScaling(train_df; cols=[:temperature]);
 
-julia> FeatureTransforms.apply!(train_df, scaling; cols=output_cols)
+julia> hum_scaling = MeanStdScaling(train_df; cols=[:humidity]);
+
+julia> FeatureTransforms.apply!(train_df, temp_scaling; cols=[:temperature]);
+
+julia> FeatureTransforms.apply!(train_df, hum_scaling; cols=[:humidity])
 22×4 DataFrame
  Row │ time                 temperature  humidity     hour_of_day_sin
      │ DateTime             Float64      Float64      Float64
@@ -112,7 +116,9 @@ julia> FeatureTransforms.apply!(train_df, scaling; cols=output_cols)
 We can use the same `scaling` transform to normalize the test data:
 
 ```jldoctest example
-julia> FeatureTransforms.apply!(test_df, scaling; cols=output_cols)
+julia> FeatureTransforms.apply!(test_df, temp_scaling; cols=[:temperature]);
+
+julia> FeatureTransforms.apply!(test_df, hum_scaling; cols=[:humidity])
 2×4 DataFrame
  Row │ time                 temperature  humidity  hour_of_day_sin
      │ DateTime             Float64      Float64   Float64
@@ -127,7 +133,9 @@ We can scale this back to the original units of temperature and humidity by conv
 ```jldoctest example
 julia> predictions = DataFrame([-0.36 0.61; -0.45 0.68], output_cols);
 
-julia> FeatureTransforms.apply!(predictions, scaling; cols=output_cols, inverse=true)
+julia> FeatureTransforms.apply!(predictions, temp_scaling; cols=[:temperature], inverse=true);
+
+julia> FeatureTransforms.apply!(predictions, hum_scaling; cols=[:humidity], inverse=true)
 2×2 DataFrame
  Row │ temperature  humidity 
      │ Float64      Float64  

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -80,16 +80,16 @@ julia> output_cols = [:temperature, :humidity];
 
 For many models it is helpful to normalize the training data.
 We can use `MeanStdScaling` for that purpose.
-Note that we are mutating the data frame in-place using `apply!`, and the order of columns specified does not matter.
+Note that we are mutating the data frame in-place using `apply!` one column at a time.
 
 ```jldoctest example
-julia> temp_scaling = MeanStdScaling(train_df; cols=[:temperature]);
+julia> temp_scaling = MeanStdScaling(train_df; cols=:temperature);
 
-julia> hum_scaling = MeanStdScaling(train_df; cols=[:humidity]);
+julia> hum_scaling = MeanStdScaling(train_df; cols=:humidity);
 
-julia> FeatureTransforms.apply!(train_df, temp_scaling; cols=[:temperature]);
+julia> FeatureTransforms.apply!(train_df, temp_scaling; cols=:temperature);
 
-julia> FeatureTransforms.apply!(train_df, hum_scaling; cols=[:humidity])
+julia> FeatureTransforms.apply!(train_df, hum_scaling; cols=:humidity)
 22×4 DataFrame
  Row │ time                 temperature  humidity     hour_of_day_sin
      │ DateTime             Float64      Float64      Float64
@@ -116,9 +116,9 @@ julia> FeatureTransforms.apply!(train_df, hum_scaling; cols=[:humidity])
 We can use the same `scaling` transform to normalize the test data:
 
 ```jldoctest example
-julia> FeatureTransforms.apply!(test_df, temp_scaling; cols=[:temperature]);
+julia> FeatureTransforms.apply!(test_df, temp_scaling; cols=:temperature);
 
-julia> FeatureTransforms.apply!(test_df, hum_scaling; cols=[:humidity])
+julia> FeatureTransforms.apply!(test_df, hum_scaling; cols=:humidity)
 2×4 DataFrame
  Row │ time                 temperature  humidity  hour_of_day_sin
      │ DateTime             Float64      Float64   Float64
@@ -133,9 +133,9 @@ We can scale this back to the original units of temperature and humidity by conv
 ```jldoctest example
 julia> predictions = DataFrame([-0.36 0.61; -0.45 0.68], output_cols);
 
-julia> FeatureTransforms.apply!(predictions, temp_scaling; cols=[:temperature], inverse=true);
+julia> FeatureTransforms.apply!(predictions, temp_scaling; cols=:temperature, inverse=true);
 
-julia> FeatureTransforms.apply!(predictions, hum_scaling; cols=[:humidity], inverse=true)
+julia> FeatureTransforms.apply!(predictions, hum_scaling; cols=:humidity, inverse=true)
 2×2 DataFrame
  Row │ temperature  humidity 
      │ Float64      Float64  

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -76,10 +76,8 @@ function apply(A::AbstractArray, t::Transform; dims=:, inds=:, kwargs...)
         end
     end
 
-    slice_index = 0
     return @views mapslices(A, dims=dims) do x
-        slice_index += 1
-        _apply(x[inds], t; name=Symbol(slice_index), kwargs...)
+        _apply(x[inds], t; kwargs...)
     end
 end
 
@@ -115,7 +113,7 @@ end
 
 # 3-arg forms are simply to dispatch on whether cols is a Symbol or a collection
 function _apply(table, t::Transform, col; kwargs...)
-    return _apply(getproperty(table, col), t; name=col, kwargs...)
+    return _apply(getproperty(table, col), t; kwargs...)
 end
 
 function _apply(table, t::Transform, cols::Union{Tuple, AbstractArray}; kwargs...)
@@ -140,7 +138,7 @@ function apply!(table::T, t::Transform; cols=nothing, kwargs...)::T where T
 
     cnames = cols === nothing ? propertynames(columntable) : cols
     for cname in cnames
-        apply!(getproperty(columntable, cname), t; name=cname, kwargs...)
+        apply!(getproperty(columntable, cname), t; kwargs...)
     end
 
     return table


### PR DESCRIPTION
## Proposed Solution

When constructing `MeanStdScaling` it should compute a _single_ mean and std pair for all the data it is given and no longer compute it on a slice-by-slice basis.

This PR:
* Simplifies the code in `scaling.jl`
* Simplifies the constructor and formats it consistently no matter what data it was given
* Simplifies the parent `apply` functions (which no longer need to pass `name` downstream)
* De-couples the `MeanStdScaling` from the data, allowing it operate as an independent `Transform` like any other.
* Makes it's application more consistent with other transforms, i.e. "apply the transform to all the data it's given" rather than assuming it needs to be applied slice-by-slice (which no other transform does).

Cons:
* Now need to construct separate `MeanStdScaling` transforms for each column if you wish to use more than one. It's possible we can make a helper util for this in future.

## Problem Description

There are a few peculiarities with the way the `MeanStdScaling` transform is implemented that has given rise to some code smell.

1. We parse  a `name` kwarg in the parent `apply` method that only applies to this transform, which complicates the code in `apply` and gives a false impression that `name` is universal.
2. Keeping track of the names in `scaling` is also complicated and the way the constructor is handled differs whether it was computed using an array or table, and if it used all the data or not.
3. `MeanStdScaling` is not an independent transform; it is coupled directly to the data that created it (one cannot rename a column afterwards for example).
4. How it's used is also inconsistent with our other transforms (see example below)
5. Finally, using `mapslices` may not be the best idea after all (https://github.com/invenia/FeatureTransforms.jl/issues/18#issuecomment-786877479) and AxisArrays doesn't natively support it (it also doesn't look like anyone's in a rush to put it in https://github.com/JuliaArrays/AxisArrays.jl/pull/195) but refactoring that part was impossible without simplifying this first.

On point 3. Let's consider how a more simple transform, e.g. `Power`, operates
```julia
julia> A = [1 2; 5 9; 8 10];

julia> p = Power(3);
Power(3)
```

The default behaviour is that transform is applied to all of the data.
More specifically, the parameter `p.exponent` is applied uniformly to all of the data it is given.
We don't compute /apply a separate exponent to each slice (hint hint).
Although we can restrict it to certain slices of the data if we want.
```julia
julia> FeatureTransforms.apply(A, p)
3×2 Array{Int64,2}:
   1     8
 125   729
 512  1000

julia> FeatureTransforms.apply(A, p; dims=1, inds=1)
1×2 Array{Int64,2}:
 1  8
```

Compare this with `MeanStdScaling`, which is special because the constructor needs to first parse the data to create the transform and so the parameters will depend on what we give it.
But the same principle of "apply the same parameters to all the data" should still hold.

Looking at how we pass in the data, the first problem is that it can change how the constructor is represented, which makes it difficult to wrangle in the code.
Moreover, it's not obvious what these parameters mean.
```julia
julia> scaling_all = MeanStdScaling(A)
MeanStdScaling((all = 5.833333333333333,), (all = 3.7638632635454052,))

julia> scaling_selected = MeanStdScaling(A; dims=1)
MeanStdScaling((1 = 4.666666666666667, 2 = 7.0), (1 = 3.5118845842842465, 2 = 4.358898943540674))
```

Second, it makes the assumption that we want separate scaling parameters for each slice.
(This feature probably comes from my [earlier suggestion](https://github.com/invenia/FeatureTransforms.jl/issues/3#issuecomment-777655342) but that comment should have been clearer to prioritise simplicity.)

What this means is that when applying this to `A`, different elements are transformed by different variables, which violates the principle above.

```julia
julia> FeatureTransforms.apply(A, scaling_all)
3×2 Array{Float64,2}:
 -1.28414   -1.01846
 -0.221404   0.841334
  0.57565    1.10702

julia> FeatureTransforms.apply(A, scaling_selected; dims=1)
3×2 Array{Float64,2}:
 -1.04407    -1.14708
  0.0949158   0.458831
  0.949158    0.688247
```

Finally, the transform is overly-coupled to the data it was computed on. 
While it should have a memory of this data (as it is stateful) that memory lies in the scaling parameters themselves, after computing these it should operate as an independent transform like any other.
But right now, applying it to certain `dims`, `inds` and `cols` relies too heavily on the original data and it is therefore too brittle and restrictive.

Compare with this branch.
The scaling is computed across all data it is given, `dims` doesn't matter unless `inds` is provided.
And it returns a consistent constructor now matter what format it's in.
```julia
julia> A = [1 2; 5 9; 8 10];

julia> scaling = MeanStdScaling(A)
MeanStdScaling(5.833333333333333, 3.7638632635454052)

julia> scaling = MeanStdScaling(A; dims=1)
MeanStdScaling(5.833333333333333, 3.7638632635454052)

julia> scaling = MeanStdScaling(A; dims=1, inds=1)
MeanStdScaling(1.5, 0.7071067811865476)
```

Afterwards, the `scaling` is an independent transform like any other and can be applied freely.
This takes into account the data may have changed (via other transforms) so the user should be able to specify what to apply it to.
```julia
julia> FeatureTransforms.apply(A, scaling)
3×2 Array{Float64,2}:
 -0.707107   0.707107
  4.94975   10.6066
  9.19239   12.0208

julia> FeatureTransforms.apply(A, scaling; dims=1, inds=[2])
1×2 Array{Float64,2}:
 4.94975  10.6066
```

I'll note that I think this also closes #39 in that it transforming the second column is consistent. 
This is thanks to `scaling` now acting like an independent transform.
```julia
julia> M = reshape(collect(1:6), 3, 2);

#normalise the second column
julia> scaling = MeanStdScaling(M; dims=2, inds=2)
MeanStdScaling(5.0, 1.0)

julia> FeatureTransforms.apply(M, scaling; dims=2, inds=[2])
3×1 Array{Float64,2}:
 -1.0
  0.0
  1.0
```