### PR TITLE
Replace mapslices with selectdim

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureTransforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -123,8 +123,7 @@ For example, given a `Matrix`, `dims=1` slices the data column-wise and `inds=[2
 
 !!! note
 
-    In general, the `dims` argument uses the convention of `mapslices`, which is called behind the scenes when applying transforms to slices of data.
-    In practice, this means that users can expect the `dims` keyword to behave exactly as `mean(A; dims=d)` would; the transformation will be applied to the elements along the dimension `d` and, for operations like `mean` or `sum`, reduce across this dimension.
+    In general, users can expect the `dims` keyword to behave exactly as `mean(A; dims=d)` would; the transformation will be applied to the elements along the dimension `d` and, for operations like `mean` or `sum`, reduce across this dimension.
 
 ```jldoctest transforms
 julia> M

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -76,9 +76,7 @@ function apply(A::AbstractArray, t::Transform; dims=:, inds=:, kwargs...)
         end
     end
 
-    return @views mapslices(A, dims=dims) do x
-        _apply(x[inds], t; kwargs...)
-    end
+    return _apply(selectdim(A, dims, inds), t; kwargs...)
 end
 
 """

--- a/test/one_hot_encoding.jl
+++ b/test/one_hot_encoding.jl
@@ -35,8 +35,8 @@
             @test FeatureTransforms.apply(x, ohe; inds=2:4) == [0 0 1; 0 1 0; 0 0 1]
             @test FeatureTransforms.apply(x, ohe; dims=:) == expected
 
-            @test_throws DimensionMismatch FeatureTransforms.apply(x, ohe; dims=1)
-            @test_throws DimensionMismatch FeatureTransforms.apply(x, ohe; dims=1, inds=[2, 4])
+            @test FeatureTransforms.apply(x, ohe; dims=1) == expected
+            @test FeatureTransforms.apply(x, ohe; dims=1, inds=[2, 4]) == [0 0 1; 0 0 1]
 
             @test_throws BoundsError FeatureTransforms.apply(x, ohe; dims=2)
         end
@@ -51,10 +51,8 @@
 
         @test FeatureTransforms.apply(M, ohe) == expected
 
-        @testset "dims" begin
-            @test FeatureTransforms.apply(M, ohe; dims=:) == expected
-            @test_throws DimensionMismatch FeatureTransforms.apply(M, ohe; dims=1)
-            @test_throws DimensionMismatch FeatureTransforms.apply(M, ohe; dims=2)
+        @testset "dims=:$d" for d in (1, 2, Colon())
+            @test FeatureTransforms.apply(M, ohe; dims=d) == expected
         end
 
         @testset "inds" begin
@@ -68,14 +66,11 @@
         A = AxisArray(M, foo=["a", "b"], bar=["x", "y"])
         expected = [1 0 0 0 0; 0 0 0 1 0; 0 1 0 0 0; 0 0 0 0 1]
 
-        @testset "dims" begin
-            transformed = FeatureTransforms.apply(A, ohe; dims=:)
+        @testset "dims = $d" for d in (1, 2, Colon())
+            transformed = FeatureTransforms.apply(A, ohe; dims=d)
             # AxisArray doesn't preserve the type it operates on
             @test transformed isa AbstractArray
             @test transformed == expected
-
-            @test_throws DimensionMismatch FeatureTransforms.apply(A, ohe; dims=1)
-            @test_throws DimensionMismatch FeatureTransforms.apply(A, ohe; dims=2)
         end
 
         @testset "inds" begin
@@ -89,14 +84,11 @@
         A = KeyedArray(M, foo=["a", "b"], bar=["x", "y"])
         expected = [1 0 0 0 0; 0 0 0 1 0; 0 1 0 0 0; 0 0 0 0 1]
 
-        @testset "dims" begin
-            transformed = FeatureTransforms.apply(A, ohe; dims=:)
+        @testset "dims = $d" for d in (1, 2, Colon())
+            transformed = FeatureTransforms.apply(A, ohe; dims=d)
             # This transform doesn't preserve the type it operates on
             @test transformed isa AbstractArray
             @test transformed == expected
-
-            @test_throws DimensionMismatch FeatureTransforms.apply(A, ohe; dims=1)
-            @test_throws DimensionMismatch FeatureTransforms.apply(A, ohe; dims=2)
         end
 
         @testset "inds" begin


### PR DESCRIPTION
This PR replaces the call to `mapslices` with a call to `selectdim` instead.

We change this now because we no longer need to take slices in the parent `apply` method(s) (https://github.com/invenia/FeatureTransforms.jl/pull/42). 
So we can replace `mapslices` with `selectdim` instead, which is simpler and _much_ more performant (see below), yet keeps the desired `dims` convention.

## background
This is a follow up to https://github.com/invenia/FeatureTransforms.jl/pull/42, which removed the need for looping over the slices in `apply`, and https://github.com/invenia/FeatureTransforms.jl/pull/25, which was aimed at solving our `dims` convention https://github.com/invenia/FeatureTransforms.jl/issues/18.

We originally liked `mapslices` because we wanted to adopt its `dims` convention, which was more intuitive to our users.
However, it has some considerable downsides that make it a poor choice in the long-term, namely:
* Greater attention and long-term development going into `eachslice`
  *  https://github.com/JuliaLang/julia/pull/32310 introducing `SlicedArrays` and abstracting the `dims` argument.
* Much poorer performance compared to `eachslice` 
  * https://github.com/JuliaLang/julia/issues/26868
  * https://github.com/JuliaLang/julia/issues/26232
* Cannot return a `view` https://github.com/JuliaLang/julia/issues/29146
* No support in AxisArrays (but given the above there won't be a hurry to https://github.com/JuliaArrays/AxisArrays.jl/pull/195)

Its one technical advantage was allowing multiple `dims`, but this isn't a necessary feature right now.

Comparing to [previous benchmarks](https://github.com/invenia/FeatureTransforms.jl/pull/25#issuecomment-784184604) this significantly reduces allocations (x100) for element-wise transforms (although `MeanStdScaling` is a bit of an unfair comparison since it has been simplified in the meantime). It might be worth looking to make the rest more efficient also.

```julia
# Periodic - this branch
# apply
0.333721 seconds (1.46 M allocations: 70.581 MiB, 7.08% gc time)
0.000225 seconds (11 allocations: 234.734 KiB)
# apply!
0.014992 seconds (31.75 k allocations: 1.924 MiB)
0.000282 seconds (10 allocations: 234.703 KiB)

# Periodic - main
apply
0.780758 seconds (2.84 M allocations: 146.639 MiB, 5.11% gc time)
0.000626 seconds (1.64 k allocations: 380.922 KiB)
apply!
0.027169 seconds (71.10 k allocations: 4.024 MiB)
0.000667 seconds (1.64 k allocations: 380.922 KiB)

# Power - this branch
# apply
0.080944 seconds (282.02 k allocations: 14.327 MiB)
0.000037 seconds (10 allocations: 78.516 KiB)
# apply!
0.031575 seconds (50.51 k allocations: 2.755 MiB, 39.06% gc time)
0.000034 seconds (9 allocations: 78.500 KiB)

# Power - main
# apply
0.160279 seconds (347.52 k allocations: 18.862 MiB)
0.000445 seconds (1.74 k allocations: 221.500 KiB)
# apply!
0.007062 seconds (5.40 k allocations: 417.305 KiB)
0.000387 seconds (1.74 k allocations: 221.500 KiB)

# MeanStdScaling - this branch
# apply
0.168360 seconds (606.91 k allocations: 31.994 MiB)
0.000052 seconds (13 allocations: 78.734 KiB)
# apply!
0.005720 seconds (2.72 k allocations: 229.367 KiB)
0.000019 seconds (13 allocations: 78.734 KiB)

# MeanStdScaling - main
# apply
0.184251 seconds (419.53 k allocations: 22.622 MiB, 5.67% gc time)
0.000619 seconds (2.04 k allocations: 234.000 KiB)
# apply!
0.007365 seconds (5.70 k allocations: 430.008 KiB)
0.000334 seconds (2.04 k allocations: 234.000 KiB)

# LinearCombination - this branch
# apply
0.342954 seconds (1.24 M allocations: 63.726 MiB, 6.75% gc time)
0.001046 seconds (30.61 k allocations: 812.000 KiB)

# LinearCombination - main
# apply
0.329633 seconds (1.26 M allocations: 64.869 MiB, 3.28% gc time)
0.000814 seconds (30.61 k allocations: 812.000 KiB)

# OneHotEncoding - this branch
# apply
0.057715 seconds (240.52 k allocations: 11.567 MiB)
0.000384 seconds (10.01 k allocations: 254.109 KiB)

# OneHotEncoding - main
# apply
0.021401 seconds (31.42 k allocations: 1.939 MiB)
0.000913 seconds (11.98 k allocations: 968.531 KiB)
"""
```