### PR TITLE
Refactor LinearCombination

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureTransforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -19,17 +19,22 @@ end
 _sum_row(row, coefficients) = sum(map(*, row, coefficients))
 
 """
-    apply(A::AbstractArray, LC::LinearCombination; dims=1, inds=:)
+    apply(
+        ::AbstractArray{<:Real, N}, ::LinearCombination; dims=1, inds=:
+    ) -> AbstractArray{<:Real, N-1}
 
-Applies the [`LinearCombination`](@ref) to each of the specified indices in `A`, reducing
-along the `dim` provided. The result is an (N-1)-dimensional array.
+Applies the [`LinearCombination`](@ref) to each of the specified indices in the N-dimensional
+array `A`, reducing along the `dim` provided. The result is an (N-1)-dimensional array.
 
 The default behaviour reduces along the column dimension.
 
 If no `inds` are specified, then the transform is applied to all elements.
 """
-function apply(A::AbstractArray, LC::LinearCombination; dims=1, inds=:)
-    dims === Colon() && throw(ArgumentError("dims=: is not supported, use 1 or 2 instead"))
+function apply(
+    A::AbstractArray{<:Real, N}, LC::LinearCombination; dims=1, inds=:
+)::AbstractArray{<:Real, N-1} where N
+
+    dims === Colon() && throw(ArgumentError("dims=: not supported, choose dims ∈ [1, $N]"))
 
     # Get the number of slices - error if doesn't match the number of coefficients
     num_slices = inds === Colon() ? size(A, dims) : length(inds)
@@ -42,9 +47,8 @@ end
 """
     apply(table, LC::LinearCombination; cols=nothing)
 
-Applies the [`LinearCombination`](@ref) to each of the specified cols in `table`.
-
-If no `cols` are specified, then the [`LinearCombination`](@ref) is applied to all columns.
+Applies the [`LinearCombination`](@ref) across the specified cols in `table`. If no `cols`
+are specified, then the [`LinearCombination`](@ref) is applied to all columns.
 """
 function apply(table, LC::LinearCombination; cols=nothing)
     Tables.istable(table) || throw(MethodError(apply, (table, LC)))

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -19,27 +19,14 @@ end
 _sum_row(row, coefficients) = sum(map(*, row, coefficients))
 
 """
-    apply(x::AbstractVector, LC::LinearCombination; inds=:)
-
-Applies the [`LinearCombination`](@ref) to each of the specified indices in `x`.
-
-If no `inds` are specified, then the [`LinearCombination`](@ref) is applied to all elements.
-"""
-function apply(x::AbstractVector, LC::LinearCombination; inds=:)
-    # Treat each element as it's own column - error if not equal to number of coefficients
-    num_elems = inds === Colon() ? length(x) : length(inds)
-    _check_dimensions_match(LC, num_elems)
-
-    return [_sum_row(x[inds], LC.coefficients)]
-end
-
-"""
     apply(A::AbstractArray, LC::LinearCombination; dims=1, inds=:)
 
-Applies the [`LinearCombination`](@ref) to each of the specified indices in `A` along the
-dimension specified, which defaults to applying it row-wise for each column of `A`.
+Applies the [`LinearCombination`](@ref) to each of the specified indices in `A`, reducing
+along the `dim` provided. The result is an (N-1)-dimensional array.
 
-If no `inds` are specified, then the [`LinearCombination`](@ref) is applied to all columns.
+The default behaviour reduces along the column dimension.
+
+If no `inds` are specified, then the transform is applied to all elements.
 """
 function apply(A::AbstractArray, LC::LinearCombination; dims=1, inds=:)
     dims === Colon() && throw(ArgumentError("dims=: is not supported, use 1 or 2 instead"))
@@ -50,6 +37,7 @@ function apply(A::AbstractArray, LC::LinearCombination; dims=1, inds=:)
 
     return _sum_row(eachslice(selectdim(A, dims, inds); dims=dims), LC.coefficients)
 end
+
 
 """
     apply(table, LC::LinearCombination; cols=nothing)

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -47,13 +47,11 @@ function apply(x::AbstractMatrix, LC::LinearCombination; dims=1, inds=Colon())
         throw(ArgumentError("Colon() dims is not supported, use 1 or 2 instead"))
     end
 
-    # Get the number of vectors in the dimension not specified
-    other_dim = dims ==  1 ? 2 : 1
-    num_inds = inds isa Colon ? size(x, other_dim) : length(inds)
-    # Error if dimensions don't match
+    # Get the number of slices - error if doesn't match the number of coefficients
+    num_inds = inds isa Colon ? size(x, dims) : length(inds)
     _check_dimensions_match(LC, num_inds)
-
-    return [_sum_row(row[inds], LC.coefficients) for row in eachslice(x; dims=dims)]
+    A = selectdim(x, dims, inds)
+    return _sum_row(eachslice(A; dims=dims), LC.coefficients)
 end
 
 """

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -30,6 +30,13 @@
             @test FeatureTransforms.apply(x, lc; inds=[2, 3]) == fill(-1)
             @test lc(x; inds=[2, 3]) == fill(-1)
         end
+
+        @testset "output is different type" begin
+            x = [1, 2]
+            lc = LinearCombination([.1, -.1])
+            @test FeatureTransforms.apply(x, lc) == fill(-.1)
+            @test lc(x) == fill(-.1)
+        end
     end
 
     @testset "Matrix" begin

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -76,6 +76,13 @@
         end
     end
 
+    @testset "N-dim Array" begin
+        A = reshape(1:27, 3, 3, 3)
+        lc = LinearCombination([1, -1, 1])
+        @test FeatureTransforms.apply(A, lc) == [2 11 20; 5 14 23; 8 17 26]
+        @test lc(A) == [2 11 20; 5 14 23; 8 17 26]
+    end
+
     @testset "AxisArray" begin
         A = AxisArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
         lc = LinearCombination([1, -1])

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -1,40 +1,40 @@
 @testset "linear combination" begin
 
-    lc = LinearCombination([1, -1])
-    @test lc isa Transform
+    @test LinearCombination([1, -1]) isa Transform
 
     @testset "Vector" begin
-        x = [1, 2]
-        expected = [-1]
 
         @testset "all inds" begin
-            @test FeatureTransforms.apply(x, lc) == expected
-            @test lc(x) == expected
+            x = [1, 2]
+            lc = LinearCombination([1, -1])
+            @test FeatureTransforms.apply(x, lc) == [-1]
+            @test lc(x) == [-1]
         end
 
         @testset "dims not supported" begin
+            x = [1, 2]
+            lc = LinearCombination([1, -1])
             @test_throws  MethodError FeatureTransforms.apply(x, lc; dims=1)
         end
 
         @testset "dimension mismatch" begin
             x = [1, 2, 3]
+            lc = LinearCombination([1, -1])
             @test_throws DimensionMismatch FeatureTransforms.apply(x, lc)
         end
 
         @testset "specified inds" begin
             x = [1, 2, 3]
-            inds = [2, 3]
-            expected = [-1]
-
-            @test FeatureTransforms.apply(x, lc; inds=inds) == expected
-            @test lc(x; inds=inds) == expected
+            lc = LinearCombination([1, -1])
+            @test FeatureTransforms.apply(x, lc; inds=[2, 3]) == [-1]
+            @test lc(x; inds=[2, 3]) == [-1]
         end
     end
 
     @testset "Matrix" begin
-        M = [1 1; 2 2; 3 5]
 
         @testset "default reduces over columns" begin
+            M = [1 1; 2 2; 3 5]
             lc = LinearCombination([1, -1, 1])
             @test FeatureTransforms.apply(M, lc) == [2, 4]
             @test lc(M) == [2, 4]
@@ -42,22 +42,22 @@
 
         @testset "dims" begin
             @testset "dims = :" begin
-                d = Colon()
+                M = [1 1; 2 2; 3 5]
                 lc = LinearCombination([1, -1, 1])
-                @test_throws ArgumentError FeatureTransforms.apply(M, lc; dims=d)
+                @test_throws ArgumentError FeatureTransforms.apply(M, lc; dims=:)
             end
 
             @testset "dims = 1" begin
-                d = 1
+                M = [1 1; 2 2; 3 5]
                 lc = LinearCombination([1, -1, 1])
-                @test FeatureTransforms.apply(M, lc; dims=d) == [2, 4]
-                @test lc(M; dims=d) == [2, 4]
+                @test FeatureTransforms.apply(M, lc; dims=1) == [2, 4]
+                @test lc(M; dims=1) == [2, 4]
             end
 
             @testset "dims = 2" begin
-                d = 2
+                M = [1 1; 2 2; 3 5]
                 lc = LinearCombination([1, -1])
-                @test FeatureTransforms.apply(M, lc; dims=d) == [0, 0, -2]
+                @test FeatureTransforms.apply(M, lc; dims=2) == [0, 0, -2]
             end
         end
 
@@ -70,38 +70,33 @@
         @testset "specified inds" begin
             M = [1 1; 5 2; 2 4]
             lc = LinearCombination([1, -1])
-            inds = [2, 3]
-
-            @test FeatureTransforms.apply(M, lc; inds=inds) == [3, -2]
-            @test lc(M; inds=inds) == [3, -2]
+            @test FeatureTransforms.apply(M, lc; inds=[2, 3]) == [3, -2]
+            @test lc(M; inds=[2, 3]) == [3, -2]
         end
     end
 
     @testset "AxisArray" begin
         A = AxisArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
-        expected = [-3, -3]
+        lc = LinearCombination([1, -1])
 
         @testset "all inds" begin
-            @test FeatureTransforms.apply(A, lc) == expected
-            @test lc(A) == expected
+            @test FeatureTransforms.apply(A, lc) == [-3, -3]
+            @test lc(A) == [-3, -3]
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
-                d = Colon()
-                @test_throws ArgumentError FeatureTransforms.apply(A, lc; dims=d)
+                @test_throws ArgumentError FeatureTransforms.apply(A, lc; dims=:)
             end
 
             @testset "dims = 1" begin
-                d = 1
-                @test FeatureTransforms.apply(A, lc; dims=d) == expected
-                @test lc(A; dims=d) == expected
+                @test FeatureTransforms.apply(A, lc; dims=1) == [-3, -3]
+                @test lc(A; dims=1) == [-3, -3]
             end
 
             @testset "dims = 2" begin
-                d = 2
-                @test FeatureTransforms.apply(A, lc; dims=d) == [-1, -1]
-                @test lc(A; dims=d) == [-1, -1]
+                @test FeatureTransforms.apply(A, lc; dims=2) == [-1, -1]
+                @test lc(A; dims=2) == [-1, -1]
             end
         end
 
@@ -112,39 +107,33 @@
 
         @testset "specified inds" begin
             A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            inds = [1, 2]
-            expected = [-3, -3, -2]
-
-            @test FeatureTransforms.apply(A, lc; inds=inds) == expected
-            @test lc(A; inds=inds) == expected
+            @test FeatureTransforms.apply(A, lc; inds=[1, 2]) == [-3, -3, -2]
+            @test lc(A; inds=[1, 2]) == [-3, -3, -2]
         end
     end
 
     @testset "AxisKey" begin
         A = KeyedArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
-        expected = [-3, -3]
+        lc = LinearCombination([1, -1])
 
         @testset "all inds" begin
-            @test FeatureTransforms.apply(A, lc) == expected
-            @test lc(A) == expected
+            @test FeatureTransforms.apply(A, lc) == [-3, -3]
+            @test lc(A) == [-3, -3]
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
-                d = Colon()
-                @test_throws ArgumentError FeatureTransforms.apply(A, lc; dims=d)
+                @test_throws ArgumentError FeatureTransforms.apply(A, lc; dims=:)
             end
 
             @testset "dims = 1" begin
-                d = 1
-                @test FeatureTransforms.apply(A, lc; dims=d) == expected
-                @test lc(A; dims=d) == expected
+                @test FeatureTransforms.apply(A, lc; dims=1) == [-3, -3]
+                @test lc(A; dims=1) == [-3, -3]
             end
 
             @testset "dims = 2" begin
-                d = 2
-                @test FeatureTransforms.apply(A, lc; dims=d) == [-1, -1]
-                @test lc(A; dims=d) == [-1, -1]
+                @test FeatureTransforms.apply(A, lc; dims=2) == [-1, -1]
+                @test lc(A; dims=2) == [-1, -1]
             end
         end
 
@@ -155,44 +144,41 @@
 
         @testset "specified inds" begin
             A = KeyedArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            inds = [1, 2]
-            expected = [-3, -3, -2]
-
-            @test FeatureTransforms.apply(A, lc; inds=inds) == expected
-            @test lc(A; inds=inds) == expected
+            @test FeatureTransforms.apply(A, lc; inds=[1, 2]) == [-3, -3, -2]
+            @test lc(A; inds=[1, 2]) == [-3, -3, -2]
         end
     end
 
     @testset "NamedTuple" begin
-        nt = (a = [1, 2, 3], b = [4, 5, 6])
-        expected = [-3, -3, -3]
-
         @testset "all cols" begin
-            @test FeatureTransforms.apply(nt, lc) == expected
-            @test lc(nt) == expected
+            nt = (a = [1, 2, 3], b = [4, 5, 6])
+            lc = LinearCombination([1, -1])
+            @test FeatureTransforms.apply(nt, lc) == [-3, -3, -3]
+            @test lc(nt) == [-3, -3, -3]
         end
 
         @testset "dims not supported" begin
+            nt = (a = [1, 2, 3], b = [4, 5, 6])
+            lc = LinearCombination([1, -1])
             @test_throws MethodError FeatureTransforms.apply(nt, lc; dims=1)
         end
 
         @testset "dimension mismatch" begin
             nt = (a = [1, 2, 3], b = [4, 5, 6], c = [1, 1, 1])
+            lc = LinearCombination([1, -1])
             @test_throws DimensionMismatch FeatureTransforms.apply(nt, lc)
         end
 
         @testset "specified cols" begin
             nt = (a = [1, 2, 3], b = [4, 5, 6], c = [1, 1, 1])
-            cols = [:a, :b]
-            expected = [-3, -3, -3]
-
-            @test FeatureTransforms.apply(nt, lc; cols=cols) == expected
-            @test lc(nt; cols=cols) == expected
+            lc = LinearCombination([1, -1])
+            @test FeatureTransforms.apply(nt, lc; cols=[:a, :b]) == [-3, -3, -3]
+            @test lc(nt; cols=[:a, :b]) == [-3, -3, -3]
         end
 
         @testset "single col" begin
+            nt = (a = [1, 2, 3], b = [4, 5, 6])
             lc_single = LinearCombination([-1])
-
             @test FeatureTransforms.apply(nt, lc_single; cols=:a) == [-1, -2, -3]
             @test FeatureTransforms.apply(nt, lc_single; cols=[:a]) == [-1, -2, -3]
             @test lc_single(nt; cols=:a) == [-1, -2, -3]
@@ -200,35 +186,36 @@
     end
 
     @testset "DataFrame" begin
-        df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6])
-        expected = [-3, -3, -3]
 
         @testset "all cols" begin
-            @test FeatureTransforms.apply(df, lc) == expected
-            @test lc(df) == expected
+            df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6])
+            lc = LinearCombination([1, -1])
+            @test FeatureTransforms.apply(df, lc) == [-3, -3, -3]
+            @test lc(df) == [-3, -3, -3]
         end
 
         @testset "dims not supported" begin
+            df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6])
+            lc = LinearCombination([1, -1])
             @test_throws MethodError FeatureTransforms.apply(df, lc; dims=1)
         end
 
         @testset "dimension mismatch" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [1, 1, 1])
+            lc = LinearCombination([1, -1])
             @test_throws DimensionMismatch FeatureTransforms.apply(df, lc)
         end
 
         @testset "specified cols" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [1, 1, 1])
-            cols = [:b, :c]
-            expected = [3, 4, 5]
-
-            @test FeatureTransforms.apply(df, lc; cols=cols) == expected
-            @test lc(df; cols=cols) == expected
+            lc = LinearCombination([1, -1])
+            @test FeatureTransforms.apply(df, lc; cols=[:b, :c]) == [3, 4, 5]
+            @test lc(df; cols=[:b, :c]) == [3, 4, 5]
         end
 
         @testset "single col" begin
+            df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6])
             lc_single = LinearCombination([-1])
-
             @test FeatureTransforms.apply(df, lc_single; cols=:a) == [-1, -2, -3]
             @test FeatureTransforms.apply(df, lc_single; cols=[:a]) == [-1, -2, -3]
             @test lc_single(df; cols=:a) == [-1, -2, -3]

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -33,54 +33,53 @@
 
     @testset "Matrix" begin
         M = [1 1; 2 2; 3 5]
-        expected = [0, 0, -2]
 
-        @testset "all inds" begin
-            @test FeatureTransforms.apply(M, lc) == expected
-            @test lc(M) == expected
+        @testset "default reduces over columns" begin
+            lc = LinearCombination([1, -1, 1])
+            @test FeatureTransforms.apply(M, lc) == [2, 4]
+            @test lc(M) == [2, 4]
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
                 d = Colon()
+                lc = LinearCombination([1, -1, 1])
                 @test_throws ArgumentError FeatureTransforms.apply(M, lc; dims=d)
             end
 
             @testset "dims = 1" begin
                 d = 1
-                @test FeatureTransforms.apply(M, lc; dims=d) == expected
-                @test lc(M; dims=d) == expected
+                lc = LinearCombination([1, -1, 1])
+                @test FeatureTransforms.apply(M, lc; dims=d) == [2, 4]
+                @test lc(M; dims=d) == [2, 4]
             end
 
             @testset "dims = 2" begin
                 d = 2
-                # There are 3 rows so trying to apply along dim 2 without specifying inds
-                # won't work
-                @test_throws DimensionMismatch FeatureTransforms.apply(M, lc; dims=d)
-
-                @test FeatureTransforms.apply(M, lc; dims=d, inds=[2, 3]) == [-1, -3]
-                @test lc(M; dims=d, inds=[1, 3]) == [-2, -4]
+                lc = LinearCombination([1, -1])
+                @test FeatureTransforms.apply(M, lc; dims=d) == [0, 0, -2]
             end
         end
 
         @testset "dimension mismatch" begin
             M = [1 1 1; 2 2 2]
+            lc = LinearCombination([1, -1, 1])  # there are only 2 rows
             @test_throws DimensionMismatch FeatureTransforms.apply(M, lc)
         end
 
         @testset "specified inds" begin
-            M = [1 1 5; 2 2 4]
+            M = [1 1; 5 2; 2 4]
+            lc = LinearCombination([1, -1])
             inds = [2, 3]
-            expected = [-4, -2]
 
-            @test FeatureTransforms.apply(M, lc; inds=inds) == expected
-            @test lc(M; inds=inds) == expected
+            @test FeatureTransforms.apply(M, lc; inds=inds) == [3, -2]
+            @test lc(M; inds=inds) == [3, -2]
         end
     end
 
     @testset "AxisArray" begin
         A = AxisArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
-        expected = [-1, -1]
+        expected = [-3, -3]
 
         @testset "all inds" begin
             @test FeatureTransforms.apply(A, lc) == expected
@@ -101,20 +100,20 @@
 
             @testset "dims = 2" begin
                 d = 2
-                @test FeatureTransforms.apply(A, lc; dims=d) == [-3, -3]
-                @test lc(A; dims=d) == [-3, -3]
+                @test FeatureTransforms.apply(A, lc; dims=d) == [-1, -1]
+                @test lc(A; dims=d) == [-1, -1]
             end
         end
 
         @testset "dimension mismatch" begin
             A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            @test_throws DimensionMismatch FeatureTransforms.apply(A, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(A, lc; dims=2)
         end
 
         @testset "specified inds" begin
             A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
             inds = [1, 2]
-            expected = [-1, -1]
+            expected = [-3, -3, -2]
 
             @test FeatureTransforms.apply(A, lc; inds=inds) == expected
             @test lc(A; inds=inds) == expected
@@ -123,7 +122,7 @@
 
     @testset "AxisKey" begin
         A = KeyedArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
-        expected = [-1, -1]
+        expected = [-3, -3]
 
         @testset "all inds" begin
             @test FeatureTransforms.apply(A, lc) == expected
@@ -144,20 +143,20 @@
 
             @testset "dims = 2" begin
                 d = 2
-                @test FeatureTransforms.apply(A, lc; dims=d) == [-3, -3]
-                @test lc(A; dims=d) == [-3, -3]
+                @test FeatureTransforms.apply(A, lc; dims=d) == [-1, -1]
+                @test lc(A; dims=d) == [-1, -1]
             end
         end
 
         @testset "dimension mismatch" begin
             A = KeyedArray([1 2 3; 4 5 6], foo=["a", "b"], bar=["x", "y", "z"])
-            @test_throws DimensionMismatch FeatureTransforms.apply(A, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(A, lc; dims=2)
         end
 
         @testset "specified inds" begin
             A = KeyedArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
             inds = [1, 2]
-            expected = [-1, -1]
+            expected = [-3, -3, -2]
 
             @test FeatureTransforms.apply(A, lc; inds=inds) == expected
             @test lc(A; inds=inds) == expected

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -7,14 +7,15 @@
         @testset "all inds" begin
             x = [1, 2]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(x, lc) == [-1]
-            @test lc(x) == [-1]
+            @test FeatureTransforms.apply(x, lc) == fill(-1)
+            @test lc(x) == fill(-1)
         end
 
-        @testset "dims not supported" begin
+        @testset "dims behaviour" begin
             x = [1, 2]
             lc = LinearCombination([1, -1])
-            @test_throws  MethodError FeatureTransforms.apply(x, lc; dims=1)
+            @test FeatureTransforms.apply(x, lc; dims=1) == fill(-1)
+            @test_throws DimensionMismatch FeatureTransforms.apply(x, lc; dims=2)
         end
 
         @testset "dimension mismatch" begin
@@ -26,8 +27,8 @@
         @testset "specified inds" begin
             x = [1, 2, 3]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(x, lc; inds=[2, 3]) == [-1]
-            @test lc(x; inds=[2, 3]) == [-1]
+            @test FeatureTransforms.apply(x, lc; inds=[2, 3]) == fill(-1)
+            @test lc(x; inds=[2, 3]) == fill(-1)
         end
     end
 


### PR DESCRIPTION
Follow up to https://github.com/invenia/FeatureTransforms.jl/pull/45 

This PR aligns the convention for `dims` used by `LinearCombination` with that of the rest of the package.

It also decouples the tests to make them independent with some minor refactoring to the code (renaming `x` -> `A`) to make it more consistent with other files.

There is one other change implemented in https://github.com/invenia/FeatureTransforms.jl/pull/47/commits/522043004a15ebcf743ae33737322df226b91779, which might be controversial and/or out of scope but it came up in the refactoring so I'll put it here for comment.

The basic idea is that a reduction operation should reduce the dimension of the input by 1. 
That is, an N-dimensional array input should be reduced to an (N-1)-dimensional output.

This really only gets interesting when the input is a vector and N=1. Intuitively, one expects the result of this to be a scalar. But Julia actually returns a 0-dimensional array, which as far as I understand are like magic scalars? As in, you can pass them to another function by reference but they also support array-arithmetic. See:
* https://github.com/invenia/FeatureTransforms.jl/pull/47/commits/522043004a15ebcf743ae33737322df226b91779
* https://discourse.julialang.org/t/what-is-the-reason-for-a-zero-dimensional-array/7175
* https://discourse.julialang.org/t/ref-vs-zero-dimensional-arrays/24434

(I think this also makes this function type-stable since it always returns an Array?)

In any case, `main` currently returns a 1-d vector, which is definitely inconsistent given the reasoning above if you ask me.
The question is: do we trust Julia to return a 0-dim array, or do we want to override it and return a scalar explicitly?

## background

Note that we want to emulate `sum(A; dims=d)` behaviour, that is, compute the linear combination and reduce over dimension `d`.

```julia
julia> M = reshape(1:9, 3, 3)
3×3 reshape(::UnitRange{Int64}, 3, 3) with eltype Int64:
 1  4  7
 2  5  8
 3  6  9

julia> sum(M; dims=1)
1×3 Array{Int64,2}:
 6  15  24

julia> sum(M; dims=2)
3×1 Array{Int64,2}:
 12
 15
 18

```

`main` currently gives the opposite result:
```julia
julia> lc = LinearCombination([1, 1, 1])
LinearCombination(Real[1, 1, 1])

julia> FeatureTransforms.apply(M, lc; dims=1)
3-element Array{Int64,1}:
 12
 15
 18

julia> FeatureTransforms.apply(M, lc; dims=2)
3-element Array{Int64,1}:
  6
 15
 24
```

this branch gives correct result:
```julia
julia> FeatureTransforms.apply(M, lc; dims=1)
3-element Array{Int64,1}:
  6
 15
 24

julia> FeatureTransforms.apply(M, lc; dims=2)
3-element Array{Int64,1}:
 12
 15
 18
```

The changes also makes this much more performant. 
See [previous benchmarks](https://github.com/invenia/FeatureTransforms.jl/pull/25#issuecomment-784184604) for setup:
```julia
# apply: this branch
0.446041 seconds (1.70 M allocations: 89.214 MiB, 6.05% gc time)
0.000210 seconds (912 allocations: 206.688 KiB)

# apply: main
0.339547 seconds (1.27 M allocations: 65.669 MiB, 8.31% gc time)
0.000913 seconds (30.61 k allocations: 812.016 KiB
```