### PR TITLE
Remove @views from OHE

### DIFF
--- a/src/one_hot_encoding.jl
+++ b/src/one_hot_encoding.jl
@@ -36,7 +36,7 @@ function _apply(x, encoding::OneHotEncoding{R}; kwargs...) where R <: Real
     n_categories = length(encoding.categories)
     results = zeros(R, length(x), n_categories)
 
-    @views for (i, value) in enumerate(x)
+    for (i, value) in enumerate(x)
         col_pos = encoding.categories[value]
         results[i, col_pos] = true
     end


### PR DESCRIPTION
This isn't needed since we're directly applying `setindex!` on result.
Benchmarks below confirm no loss of performance

```julia
julia> using FeatureTransforms, Random

julia> Random.seed!(1);

julia> X = rand(1.0:10.0, 100, 100);

julia> t = OneHotEncoding(1:10);

julia>  @time FeatureTransforms.apply(X, t; dims=1);
           @time FeatureTransforms.apply(X, t; dims=1);
```
```
# this branch
  0.129256 seconds (685.02 k allocations: 34.652 MiB, 6.44% gc time)
  0.000381 seconds (10.01 k allocations: 254.109 KiB)

# main
  0.131076 seconds (685.94 k allocations: 34.710 MiB, 8.55% gc time)
  0.000418 seconds (10.01 k allocations: 254.109 KiB)
```