### PR TITLE
Comply with DataFrames indexing syntax

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -61,7 +61,7 @@ function apply!(A::AbstractArray, t::Transform; kwargs...)
 end
 
 """
-    apply(table, ::Transform; cols=nothing, kwargs...) -> Vector
+    apply(table, ::Transform; cols=nothing, kwargs...) -> Table
 
 Applies the [`Transform`](@ref) to each of the specified columns in the `table`.
 If no `cols` are specified, then the [`Transform`](@ref) is applied to all columns.
@@ -82,11 +82,12 @@ end
 
 # 3-arg forms are simply to dispatch on whether cols is a Symbol or a collection
 function _apply(table, t::Transform, col; kwargs...)
-    return _apply(getproperty(table, col), t; kwargs...)
+    return hcat(_apply(getproperty(table, col), t; kwargs...))
 end
 
 function _apply(table, t::Transform, cols::Union{Tuple, AbstractArray}; kwargs...)
-    return [_apply(table, t, col; kwargs...) for col in cols]
+    T = Tables.materializer(table)
+    return T(Tables.table(reduce(hcat, _apply(table, t, col; kwargs...) for col in cols)))
 end
 
 """


### PR DESCRIPTION
Fixes #55 

Note that when [using DataFrames](https://dataframes.juliadata.org/stable/man/getting_started/) indexing via a vector of column names returns another DataFrame, but indexing via single symbol returns a vector.

It was suggested that we emulate that behaviour here. However, I'm not convinced this is the correct course of action. I have an alternative suggestion in https://github.com/invenia/FeatureTransforms.jl/pull/61.

* First of all, it exposes an implementation detail specific to DataFrames, which will create a leaky abstraction. Admittedly this wasn't commented on the first time we touched on this https://github.com/invenia/FeatureTransforms.jl/pull/28.
* Secondly, DataFrames is only one type of Table we support and accommodating this will set a precedent for other similar changes in future.
* Lastly, it's making the function type-unstable (because I think the compiler ignores the keyword arg?) 
 
So overall I don't agree with this change.

```julia
julia> df = DataFrame(:a=>[1, 2, 3, 4, 5], :b=>[5, 4, 3, 2, 1]);

julia> p = Power(3);

julia> FeatureTransforms.apply(df, p, cols=:a)
5×1 Array{Int64,2}:
   1
   8
  27
  64
 125

julia> FeatureTransforms.apply(df, p, cols=[:a])
5×1 DataFrame
 Row │ Column1 
     │ Int64   
─────┼─────────
   1 │       1
   2 │       8
   3 │      27
   4 │      64
   5 │     125

julia> @code_warntype FeatureTransforms.apply(df, p, cols=:a)
Variables
  #unused#::Core.Compiler.Const(FeatureTransforms.var"#apply##kw"(), false)
  @_2::NamedTuple{(:cols,),Tuple{Symbol}}
  @_3::Core.Compiler.Const(FeatureTransforms.apply, false)
  table::DataFrame
  t::Power
  kwargs...::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}
  cols::Symbol
  @_8::Symbol

Body::Any
1 ─       Core.NewvarNode(:(kwargs...))
│   %2  = Base.haskey(@_2, :cols)::Core.Compiler.Const(true, false)
│         %2
│         (@_8 = Base.getindex(@_2, :cols))
└──       goto #3
2 ─       Core.Compiler.Const(:(@_8 = FeatureTransforms.nothing), false)
3 ┄       (cols = @_8)
│   %8  = (:cols,)::Core.Compiler.Const((:cols,), false)
│   %9  = Core.apply_type(Core.NamedTuple, %8)::Core.Compiler.Const(NamedTuple{(:cols,),T} where T<:Tuple, false)
│   %10 = Base.structdiff(@_2, %9)::Core.Compiler.Const(NamedTuple(), false)
│         (kwargs... = Base.pairs(%10))
│   %12 = FeatureTransforms.:(var"#apply#974")(cols, kwargs..., @_3, table, t)::Any
└──       return %12
```

Benchmarking confirms this is less performant but might have more to do with constructing a Table.
```julia
julia> using DataFrames, FeatureTransforms
[ Info: Precompiling FeatureTransforms [8fd68953-04b8-4117-ac19-158bf6de9782]

julia> df = DataFrame(rand(100, 100));

julia> p = Power(3);

# main
julia> @time FeatureTransforms.apply(df, p, cols=[:x1]);
  0.153022 seconds (399.12 k allocations: 21.648 MiB)
  0.000019 seconds (8 allocations: 1.203 KiB)

julia> @time FeatureTransforms.apply(df, p, cols=:x1);
  0.006716 seconds (7.00 k allocations: 427.577 KiB)
  0.000011 seconds (5 allocations: 992 bytes)

# this branch
julia> @time FeatureTransforms.apply(df, p, cols=[:x1]);
  0.351905 seconds (1.28 M allocations: 67.944 MiB, 3.32% gc time)
  0.000040 seconds (35 allocations: 5.328 KiB)

julia> @time FeatureTransforms.apply(df, p, cols=:x1);
  0.005137 seconds (7.00 k allocations: 428.202 KiB)
  0.000021 seconds (7 allocations: 1.859 KiB)
```