### PR TITLE
Return consistent table type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureTransforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -20,50 +20,70 @@ Load in the dependencies and construct some toy data.
 ```julia
 julia> using DataFrames, FeatureTransforms
 
-julia> df = DataFrame(:a=>[1, 2, 3, 4, 5], :b=>[5, 4, 3, 2, 1], :c=>[0, 1, 0, 1, 0])
+julia> df = DataFrame(:a=>[1, 2, 3, 4, 5], :b=>[5, 4, 3, 2, 1], :c=>[2, 1, 3, 1, 3])
 5×3 DataFrame
- Row │ a      b      c
-     │ Int64  Int64  Int64
+ Row │ a      b      c     
+     │ Int64  Int64  Int64 
 ─────┼─────────────────────
-   1 │     1      5      0
+   1 │     1      5      2
    2 │     2      4      1
-   3 │     3      3      0
+   3 │     3      3      3
    4 │     4      2      1
-   5 │     5      1      0
+   5 │     5      1      3
 ```
 
-We construct the transformations that we want to `apply` to the data, which can be non-mutating (`apply`) or mutating (`apply!`) if supported.
-Note that non-mutating transformations do not necessarily return the same type, even when applied to all the elements.
+Next, we construct the `Transform` that we want to `apply` to the data, which can either be non-mutating (`apply`) or mutating (`apply!`).
+All `Transforms` support the non-mutating `apply` method but any `Transform` that changes the type or dimension of the input does not support mutation.
+
+In either case, the return will be the same type as the input, so if you provide an `Array` you get back an `Array`, and if you provide a `Table` you get back a `Table`.
+Here we are working with a `DataFrame`, so the return will always be a `DataFrame`:
 ```julia
 julia> p = Power(3);
 
-julia> FeatureTransforms.apply(df, p; cols=[:a])
-1-element Array{Array{Int64,1},1}:
- [1, 8, 27, 64, 125]
+julia> FeatureTransforms.apply(df, p; cols=[:a], header=[:a3])
+5×1 DataFrame
+ Row │ a3    
+     │ Int64 
+─────┼───────
+   1 │     1
+   2 │     8
+   3 │    27
+   4 │    64
+   5 │   125
 
 julia> FeatureTransforms.apply!(df, p; cols=[:a])
 5×3 DataFrame
  Row │ a      b      c
      │ Int64  Int64  Int64
 ─────┼─────────────────────
-   1 │     1      5      0
+   1 │     1      5      2
    2 │     8      4      1
-   3 │    27      3      0
+   3 │    27      3      3
    4 │    64      2      1
-   5 │   125      1      0
+   5 │   125      1      3
 ```
 
-Also note that some transformations, such as those applying a reduction operation, do not support mutation.
-But users may append the output to their data if they so wish.
+
+`Transform`s that don't support mutation must be called using `apply` and appended.
+To help with this, you can call the `Transform` type directly:
 ```julia
+julia> ohe = OneHotEncoding(1:3);
+
 julia> lc = LinearCombination([1, -10]);
 
-julia> FeatureTransforms.apply(df, lc; cols=[:b, :c])
-5-element Array{Int64,1}:
-  5
- -6
-  3
- -8
-  1
+julia> ohe_df = ohe(df; cols=[:c], header=[:cat1, :cat2, :cat3])
+
+julia> lc_df = lc(df; cols=[:a, :b], header=[:ab]);
+
+julia> df = hcat(df, lc_df, ohe_df)
+5×7 DataFrame
+ Row │ a      b      c      ab     cat1   cat2   cat3  
+     │ Int64  Int64  Int64  Int64  Bool   Bool   Bool  
+─────┼─────────────────────────────────────────────────
+   1 │     1      5      2    -49  false   true  false
+   2 │     8      4      1    -32   true  false  false
+   3 │    27      3      3     -3  false  false   true
+   4 │    64      2      1     44   true  false  false
+   5 │   125      1      3    115  false  false   true
 
 ```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -41,7 +41,7 @@ One way to do this is with the `Periodic` transform, specifying a period of 1 da
 ```jldoctest example
 julia> periodic = Periodic(sin, Day(1));
 
-julia> df.hour_of_day_sin = FeatureTransforms.apply(df, periodic; cols=:time);
+julia> df.hour_of_day_sin = FeatureTransforms.apply(df.time, periodic);
 
 julia> feature_df = df
 24×4 DataFrame

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -66,7 +66,7 @@ end
 
 compute_stats(x) = (mean(x), std(x))
 
-function _apply(A::AbstractArray, scaling::MeanStdScaling; inverse=false, eps=1e-3)
+function _apply(A::AbstractArray, scaling::MeanStdScaling; inverse=false, eps=1e-3, kwargs...)
     inverse && return scaling.μ .+ scaling.σ .* A
     # Avoid division by 0
     # If std is 0 then data was uniform, so the scaled value would end up ≈ 0

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -175,10 +175,12 @@
             @test lc(nt) == expected
         end
 
-        @testset "dims not supported" begin
+        @testset "custom header" begin
             nt = (a = [1, 2, 3], b = [4, 5, 6])
             lc = LinearCombination([1, -1])
-            @test_throws MethodError FeatureTransforms.apply(nt, lc; dims=1)
+            expected = (x = [-3, -3, -3],)
+            @test FeatureTransforms.apply(nt, lc; header=[:x]) == expected
+            @test lc(nt; header=[:x]) == expected
         end
 
         @testset "dimension mismatch" begin
@@ -214,10 +216,12 @@
             @test lc(df) == DataFrame(:Column1 => [-3, -3, -3])
         end
 
-        @testset "dims not supported" begin
+        @testset "custom header" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6])
             lc = LinearCombination([1, -1])
-            @test_throws MethodError FeatureTransforms.apply(df, lc; dims=1)
+            expected = DataFrame(:x => [-3, -3, -3])
+            @test FeatureTransforms.apply(df, lc; header=[:x]) == expected
+            @test lc(df; header=[:x]) == expected
         end
 
         @testset "dimension mismatch" begin

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -170,8 +170,9 @@
         @testset "all cols" begin
             nt = (a = [1, 2, 3], b = [4, 5, 6])
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(nt, lc) == [-3, -3, -3]
-            @test lc(nt) == [-3, -3, -3]
+            expected = (Column1 = [-3, -3, -3],)
+            @test FeatureTransforms.apply(nt, lc) == expected
+            @test lc(nt) == expected
         end
 
         @testset "dims not supported" begin
@@ -189,16 +190,18 @@
         @testset "specified cols" begin
             nt = (a = [1, 2, 3], b = [4, 5, 6], c = [1, 1, 1])
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(nt, lc; cols=[:a, :b]) == [-3, -3, -3]
-            @test lc(nt; cols=[:a, :b]) == [-3, -3, -3]
+            expected = (Column1 = [-3, -3, -3],)
+            @test FeatureTransforms.apply(nt, lc; cols=[:a, :b]) == expected
+            @test lc(nt; cols=[:a, :b]) == expected
         end
 
         @testset "single col" begin
             nt = (a = [1, 2, 3], b = [4, 5, 6])
             lc_single = LinearCombination([-1])
-            @test FeatureTransforms.apply(nt, lc_single; cols=:a) == [-1, -2, -3]
-            @test FeatureTransforms.apply(nt, lc_single; cols=[:a]) == [-1, -2, -3]
-            @test lc_single(nt; cols=:a) == [-1, -2, -3]
+            expected = (Column1 = [-1, -2, -3],)
+            @test FeatureTransforms.apply(nt, lc_single; cols=:a) == expected
+            @test FeatureTransforms.apply(nt, lc_single; cols=[:a]) == expected
+            @test lc_single(nt; cols=:a) == expected
         end
     end
 
@@ -207,8 +210,8 @@
         @testset "all cols" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6])
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(df, lc) == [-3, -3, -3]
-            @test lc(df) == [-3, -3, -3]
+            @test FeatureTransforms.apply(df, lc) == DataFrame(:Column1 => [-3, -3, -3])
+            @test lc(df) == DataFrame(:Column1 => [-3, -3, -3])
         end
 
         @testset "dims not supported" begin
@@ -226,16 +229,19 @@
         @testset "specified cols" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [1, 1, 1])
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(df, lc; cols=[:b, :c]) == [3, 4, 5]
-            @test lc(df; cols=[:b, :c]) == [3, 4, 5]
+            expected = DataFrame(:Column1 => [3, 4, 5])
+
+            @test FeatureTransforms.apply(df, lc; cols=[:b, :c]) == expected
+            @test lc(df; cols=[:b, :c]) == expected
         end
 
         @testset "single col" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6])
             lc_single = LinearCombination([-1])
-            @test FeatureTransforms.apply(df, lc_single; cols=:a) == [-1, -2, -3]
-            @test FeatureTransforms.apply(df, lc_single; cols=[:a]) == [-1, -2, -3]
-            @test lc_single(df; cols=:a) == [-1, -2, -3]
+            expected = DataFrame(:Column1 => [-1, -2, -3])
+            @test FeatureTransforms.apply(df, lc_single; cols=:a) == expected
+            @test FeatureTransforms.apply(df, lc_single; cols=[:a]) == expected
+            @test lc_single(df; cols=:a) == expected
         end
     end
 end

--- a/test/power.jl
+++ b/test/power.jl
@@ -95,31 +95,29 @@
 
     @testset "NamedTuple" begin
         nt = (a = [1, 2, 3], b = [4, 5, 6])
-        expected = [[1, 8, 27], [64, 125, 216]]
-        expected_nt = (a = [1, 8, 27], b = [64, 125, 216])
 
         @testset "all cols" begin
-            @test FeatureTransforms.apply(nt, p) == expected
-            @test p(nt) == expected
+
+            expected_nt = (Column1 = [1, 8, 27], Column2 = [64, 125, 216])
+            @test FeatureTransforms.apply(nt, p) == expected_nt
+            @test p(nt) == expected_nt
 
             _nt = deepcopy(nt)
             FeatureTransforms.apply!(_nt, p)
             @test _nt isa NamedTuple{(:a, :b)}
-            @test _nt == expected_nt
+            @test _nt == (a = [1, 8, 27], b = [64, 125, 216])
         end
 
         @testset "cols = $c" for c in (:a, :b)
-            nt_mutated = NamedTuple{(Symbol("$c"), )}((expected_nt[c], ))
-            expected_nt_mutated = merge(nt, nt_mutated)
+            expected = getproperty(nt, c) .^3
 
-            @test FeatureTransforms.apply(nt, p; cols=[c]) == [expected_nt[c]]
-            @test FeatureTransforms.apply(nt, p; cols=c) == expected_nt[c]
-            @test p(nt; cols=[c]) == [expected_nt[c]]
+            @test FeatureTransforms.apply(nt, p; cols=c) == (Column1 = expected, )
+            @test p(nt; cols=c) == (Column1 = expected, )
 
             @testset "mutating" for _c in (c, [c])
                 _nt = deepcopy(nt)
                 FeatureTransforms.apply!(_nt, p; cols=_c)
-                @test _nt == expected_nt_mutated
+                @test _nt == merge(nt, NamedTuple{(c,)}((expected,)))
                 @test _nt isa NamedTuple
             end
         end
@@ -127,23 +125,23 @@
 
     @testset "DataFrame" begin
         df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6])
-        expected_df = DataFrame(:a => [1, 8, 27], :b => [64, 125, 216])
-        expected = [expected_df.a, expected_df.b]
 
         @testset "all cols" begin
-            @test FeatureTransforms.apply(df, p) == expected
-            @test p(df) == expected
+            expected_df = DataFrame(:Column1 => [1, 8, 27], :Column2 => [64, 125, 216])
+            @test FeatureTransforms.apply(df, p) == expected_df
+            @test p(df) == expected_df
 
             _df = deepcopy(df)
             FeatureTransforms.apply!(_df, p)
             @test _df isa DataFrame
-            @test _df == expected_df
+            @test _df == DataFrame(:a => [1, 8, 27], :b => [64, 125, 216])
         end
 
         @testset "cols = $c" for c in (:a, :b)
-            @test FeatureTransforms.apply(df, p; cols=[c]) == [expected_df[!, c]]
-            @test FeatureTransforms.apply(df, p; cols=c) == expected_df[!, c]
-            @test p(df; cols=[c]) == [expected_df[!, c]]
+            expected = getproperty(df, c) .^ 3
+            @test FeatureTransforms.apply(df, p; cols=[c]) == DataFrame(:Column1=>expected)
+            @test FeatureTransforms.apply(df, p; cols=c) == DataFrame(:Column1=>expected)
+            @test p(df; cols=[c]) == DataFrame(:Column1=>expected)
         end
     end
 end

--- a/test/power.jl
+++ b/test/power.jl
@@ -108,6 +108,12 @@
             @test _nt == (a = [1, 8, 27], b = [64, 125, 216])
         end
 
+        @testset "custom header" begin
+            expected_nt = (x = [1, 8, 27], y = [64, 125, 216])
+            @test FeatureTransforms.apply(nt, p; header=[:x, :y]) == expected_nt
+            @test p(nt; header=[:x, :y]) == expected_nt
+        end
+
         @testset "cols = $c" for c in (:a, :b)
             expected = getproperty(nt, c) .^3
 
@@ -135,6 +141,12 @@
             FeatureTransforms.apply!(_df, p)
             @test _df isa DataFrame
             @test _df == DataFrame(:a => [1, 8, 27], :b => [64, 125, 216])
+        end
+
+        @testset "custom header" begin
+            expected_df = DataFrame(:x => [1, 8, 27], :y => [64, 125, 216])
+            @test FeatureTransforms.apply(df, p; header=[:x, :y]) == expected_df
+            @test p(df; header=[:x, :y]) == expected_df
         end
 
         @testset "cols = $c" for c in (:a, :b)

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -125,47 +125,48 @@
 
         @testset "NamedTuple" begin
             nt = (a = [0.0, -0.5, 0.5], b = [1.0, 0.0, 2.0])
-            nt_expected = (a = [0.0, -0.5, 0.5], b = [1.0, 0.0, 2.0])
+            expected = (Column1 = [0.0, -0.5, 0.5], Column2 = [1.0, 0.0, 2.0])
 
-           @test FeatureTransforms.apply(nt, scaling) == [nt_expected.a, nt_expected.b]
+           @test FeatureTransforms.apply(nt, scaling) == expected
 
             @testset "Mutating" begin
                 _nt = deepcopy(nt)
                 FeatureTransforms.apply!(_nt, scaling)
-                @test _nt isa NamedTuple{(:a, :b)}
-                @test _nt == nt_expected
+                @test _nt == nt
             end
 
-            @testset "cols = $c" for c in (:a, :b)
-                @test FeatureTransforms.apply(nt, scaling; cols=[c]) ≈ [nt_expected[c]]
-                @test FeatureTransforms.apply(nt, scaling; cols=c) ≈ nt_expected[c]
+            @testset "cols = :a" begin
+                exp = (Column1=nt.a, )
+                @test FeatureTransforms.apply(nt, scaling; cols=[:a]) == exp
+                @test FeatureTransforms.apply(nt, scaling; cols=:a) == exp
             end
 
             @testset "Inverse" begin
-                @test FeatureTransforms.apply(nt, scaling; inverse=true) == [nt_expected.a, nt_expected.b]
+                @test FeatureTransforms.apply(nt, scaling; inverse=true) == expected
             end
         end
 
         @testset "DataFrame" begin
             df = DataFrame(:a => [0.0, -0.5, 0.5], :b => [1.0, 0.0, 2.0])
-            df_expected = DataFrame(:a => [0.0, -0.5, 0.5], :b => [1.0, 0.0, 2.0])
+            df_expected = DataFrame(:Column1 => [0.0, -0.5, 0.5], :Column2 => [1.0, 0.0, 2.0])
 
-            @test FeatureTransforms.apply(df, scaling) == [df_expected.a, df_expected.b]
+            @test FeatureTransforms.apply(df, scaling) == df_expected
 
             @testset "Mutating" begin
                 _df = deepcopy(df)
                 FeatureTransforms.apply!(_df, scaling)
                 @test _df isa DataFrame
-                @test _df == df_expected
+                @test _df == df
             end
 
-            @testset "cols = $c" for c in (:a, :b)
-                @test FeatureTransforms.apply(df, scaling; cols=[c]) ≈ [df_expected[!, c]]
-                @test FeatureTransforms.apply(df, scaling; cols=c) ≈ df_expected[!, c]
+            @testset "cols = :a" begin
+                expected = DataFrame(:Column1=>df.a)
+                @test FeatureTransforms.apply(df, scaling; cols=[:a]) == expected
+                @test FeatureTransforms.apply(df, scaling; cols=:a) == expected
             end
 
             @testset "Inverse" begin
-                @test FeatureTransforms.apply(df, scaling; inverse=true) == [df_expected.a, df_expected.b]
+                @test FeatureTransforms.apply(df, scaling; inverse=true) == df_expected
             end
         end
     end
@@ -466,69 +467,72 @@
         @testset "NamedTuple" begin
             nt = (a = [0.0, -0.5, 0.5], b = [1.0, 0.0, 2.0])
 
-            arr_expected = [[-0.55902, -1.11803, 0.0], [0.55902, -0.55902, 1.67705]]
-            nt_expected = (a = [0.0, -1.0, 1.0], b = [0.0, -1.0, 1.0])
-
             @testset "Non-mutating" begin
+                expected = [[-0.55902, -1.11803, 0.0], [0.55902, -0.55902, 1.67705]]
+
                 scaling = MeanStdScaling(nt)
-                @test FeatureTransforms.apply(nt, scaling) ≈ arr_expected atol=1e-5
-                @test scaling(nt) ≈ arr_expected atol=1e-5
+                result = FeatureTransforms.apply(nt, scaling)
+                @test result isa NamedTuple{(:Column1, :Column2)}
+                @test collect(result) ≈ expected atol=1e-5
+
+                result = scaling(nt)
+                @test result isa NamedTuple{(:Column1, :Column2)}
+                @test collect(result) ≈ expected atol=1e-5
             end
 
             @testset "Mutating" begin
+                expected = [[-0.55902, -1.11803, 0.0], [0.55902, -0.55902, 1.67705]]
                 scaling = MeanStdScaling(nt)
                 _nt = deepcopy(nt)
                 FeatureTransforms.apply!(_nt, scaling)
                 @test _nt isa NamedTuple{(:a, :b)}
-                @test collect(_nt) ≈ collect(arr_expected) atol=1e-5
+                @test collect(_nt) ≈ expected atol=1e-5
             end
 
-            @testset "cols = $c" for c in (:a, :b)
-                scaling = MeanStdScaling(nt; cols=[c])
-                nt_mutated = NamedTuple{(Symbol("$c"), )}((nt_expected[c], ))
-                nt_expected_ = merge(nt, nt_mutated)
+            @testset "cols = :a" begin
+                scaling = MeanStdScaling(nt; cols=:a)
 
-                @test FeatureTransforms.apply(nt, scaling; cols=[c]) ≈ [collect(nt_expected_[c])] atol=1e-14
-                @test FeatureTransforms.apply(nt, scaling; cols=c) ≈ collect(nt_expected_[c]) atol=1e-14
-                @test scaling(nt; cols=[c]) ≈ [collect(nt_expected_[c])] atol=1e-14
+                expected = (Column1 = [0.0, -1.0, 1.0], )
+                @test FeatureTransforms.apply(nt, scaling; cols=:a) == expected
+                @test FeatureTransforms.apply(nt, scaling; cols=[:a]) == expected
+                @test scaling(nt; cols=:a) == expected
 
                 _nt = deepcopy(nt)
-                FeatureTransforms.apply!(_nt, scaling; cols=[c])
-                @test _nt isa NamedTuple{(:a, :b)}  # before applying `collect`
-                @test collect(_nt) ≈ collect(nt_expected_) atol=1e-14
+                FeatureTransforms.apply!(_nt, scaling; cols=:a)
+                @test _nt == (a=[0.0, -1.0, 1.0], b=[1.0, 0.0, 2.0])
             end
 
             @testset "Re-apply" begin
                 scaling = MeanStdScaling(nt)
-                FeatureTransforms.apply(nt, scaling)
 
                 # Expect scaling parameters to be fixed to the first data applied to
                 nt2 = (a = [-1.0, 0.5, 0.0], b = [2.0, 2.0, 1.0])
                 @test nt !== nt2
-                arr_expected2 = [[-1.67705, 0.0, -0.55902], [1.67705, 1.67705, 0.55902]]
-                @test FeatureTransforms.apply(nt2, scaling) ≈ arr_expected2 atol=1e-5
+                expected2 = [[-1.67705, 0.0, -0.55902], [1.67705, 1.67705, 0.55902]]
+                @test collect(FeatureTransforms.apply(nt2, scaling)) ≈ expected2 atol=1e-5
             end
 
             @testset "Inverse" begin
                 scaling = MeanStdScaling(nt)
                 transformed = FeatureTransforms.apply(nt, scaling)
-                transformed = (a = transformed[1], b = transformed[2])
-
-                @test collect(transformed) ≈ arr_expected atol=1e-5
-                @test FeatureTransforms.apply(transformed, scaling; inverse=true) ≈ [nt.a, nt.b] atol=1e-5
+                expected_inverse = (Column1 = [0.0, -0.5, 0.5], Column2 = [1.0, 0.0, 2.0])
+                inverted = FeatureTransforms.apply(transformed, scaling; inverse=true)
+                @test expected_inverse == inverted
             end
         end
 
         @testset "DataFrame" begin
             df = DataFrame(:a => [0.0, -0.5, 0.5], :b => [1.0, 0.0, 2.0])
-            df_expected = DataFrame(:a => [0.0, -1.0, 1.0], :b => [0.0, -1.0, 1.0])
-            arr_expected = [[-0.55902, -1.11803, 0.0], [0.55902, -0.55902, 1.67705]]
+
+            df_expected = DataFrame(
+                :Column1 => [-0.55902, -1.11803, 0.0],
+                :Column2 => [0.55902, -0.55902, 1.67705],
+            )
 
             @testset "Non-mutating" begin
                 scaling = MeanStdScaling(df)
-                transformed = FeatureTransforms.apply(df, scaling)
-                @test transformed ≈ arr_expected atol=1e-5
-                @test scaling(df) ≈ arr_expected atol=1e-5
+                @test FeatureTransforms.apply(df, scaling) ≈ df_expected atol=1e-5
+                @test scaling(df) ≈ df_expected atol=1e-5
             end
 
             @testset "Mutating" begin
@@ -536,42 +540,48 @@
                 _df = deepcopy(df)
                 FeatureTransforms.apply!(_df, scaling)
                 @test _df isa DataFrame
-                @test _df ≈ DataFrame(arr_expected, [:a, :b]) atol=1e-5
+                @test isapprox(
+                    _df,
+                    DataFrame(:a => [-0.55902, -1.11803, 0.0], :b => [0.55902, -0.55902, 1.67705]),
+                    atol=1e-5
+                )
             end
 
-            @testset "cols = $c" for c in (:a, :b)
-                scaling = MeanStdScaling(df; cols=[c])
+            @testset "cols = :a" begin
+                scaling = MeanStdScaling(df; cols=:a)
 
-                @test FeatureTransforms.apply(df, scaling; cols=[c]) ≈ [df_expected[!, c]] atol=1e-5
-                @test FeatureTransforms.apply(df, scaling; cols=c) ≈ df_expected[!, c] atol=1e-5
+                @test isequal(
+                    FeatureTransforms.apply(df, scaling; cols=:a),
+                    DataFrame(:Column1 => [0.0, -1.0, 1.0]),
+                )
 
                 _df = deepcopy(df)
-                _df_expected = deepcopy(df)
-                _df_expected[!, c] = df_expected[!, c]
-                FeatureTransforms.apply!(_df, scaling; cols=[c])
+                FeatureTransforms.apply!(_df, scaling; cols=:a)
                 @test _df isa DataFrame
-                @test _df ≈ _df_expected atol=1e-5
+                @test _df == DataFrame(:a => [0.0, -1.0, 1.0], :b => [1.0, 0.0, 2.0])
             end
 
             @testset "Re-apply" begin
-                scaling = MeanStdScaling(df)
-                FeatureTransforms.apply(df, scaling)
-
                 # Expect scaling parameters to be fixed to the first data applied to
                 df2 = DataFrame(:a => [-1.0, 0.5, 0.0], :b => [2.0, 2.0, 1.0])
                 @test df !== df2
 
-                arr_expected2 = [[-1.67705, 0.0, -0.55902], [1.67705, 1.67705, 0.55902]]
-                @test FeatureTransforms.apply(df2, scaling) ≈ arr_expected2 atol=1e-5
+                scaling = MeanStdScaling(df)
+
+                df_expected2 = DataFrame(
+                    :Column1 => [-1.67705, 0.0, -0.55902],
+                    :Column2 => [1.67705, 1.67705, 0.55902],
+                )
+                @test FeatureTransforms.apply(df2, scaling) ≈ df_expected2 atol=1e-5
             end
 
             @testset "Inverse" begin
                 scaling = MeanStdScaling(df)
                 transformed = FeatureTransforms.apply(df, scaling)
-                transformed = DataFrame(transformed, [:a, :b])
 
-                @test transformed ≈ DataFrame(arr_expected, [:a, :b]) atol=1e-5
-                @test FeatureTransforms.apply(transformed, scaling; inverse=true) ≈ [df.a, df.b] atol=1e-5
+                expected_inverse = DataFrame(:Column1=>df.a, :Column2=>df.b)
+                inverted = FeatureTransforms.apply(transformed, scaling; inverse=true)
+                @test inverted == expected_inverse
             end
         end
 

--- a/test/temporal.jl
+++ b/test/temporal.jl
@@ -135,10 +135,9 @@
             a = DateTime(2020, 1, 1, 0, 0):Hour(1):DateTime(2020, 1, 1, 2, 0),
             b = DateTime(2020, 1, 1, 3, 0):Hour(1):DateTime(2020, 1, 1, 5, 0)
         )
-        expected_nt = (a = [0, 1, 2], b = [3, 4, 5])
-        expected = [[0, 1, 2], [3, 4, 5]]
 
         @testset "all cols" begin
+            expected = (Column1 = [0, 1, 2], Column2 = [3, 4, 5])
             @test FeatureTransforms.apply(nt, hod) == expected
             @test hod(nt) == expected
 
@@ -146,10 +145,11 @@
             @test nt != expected
         end
 
-        @testset "cols = $c" for c in (:a, :b)
-            @test FeatureTransforms.apply(nt, hod; cols=[c]) == [expected_nt[c]]
-            @test FeatureTransforms.apply(nt, hod; cols=c) == expected_nt[c]
-            @test hod(nt; cols=[c]) == [expected_nt[c]]
+        @testset "cols = :a" begin
+            expected = (Column1 = [0, 1, 2],)
+            @test FeatureTransforms.apply(nt, hod; cols=[:a]) == expected
+            @test FeatureTransforms.apply(nt, hod; cols=:a) == expected
+            @test hod(nt; cols=:a) == expected
         end
     end
 
@@ -159,10 +159,9 @@
             :a => DateTime(2020, 1, 1, 0, 0):Hour(1):DateTime(2020, 1, 1, 2, 0),
             :b => DateTime(2020, 1, 1, 3, 0):Hour(1):DateTime(2020, 1, 1, 5, 0)
         )
-        expected_df = DataFrame(:a => [0, 1, 2], :b => [3, 4, 5])
-        expected = [expected_df.a, expected_df.b]
 
         @testset "all cols" begin
+            expected = DataFrame(:Column1 => [0, 1, 2], :Column2 => [3, 4, 5])
             @test FeatureTransforms.apply(df, hod) == expected
             @test hod(df) == expected
 
@@ -170,8 +169,8 @@
             @test df != expected
         end
 
-        @test FeatureTransforms.apply(df, hod; cols=[:a]) == [expected_df.a]
-        @test FeatureTransforms.apply(df, hod; cols=:a) == expected_df.a
-        @test FeatureTransforms.apply(df, hod; cols=[:b]) ==[expected_df.b]
+        @test FeatureTransforms.apply(df, hod; cols=[:a]) == DataFrame(:Column1 => [0, 1, 2])
+        @test FeatureTransforms.apply(df, hod; cols=:a) == DataFrame(:Column1 => [0, 1, 2])
+        @test FeatureTransforms.apply(df, hod; cols=[:b]) == DataFrame(:Column1 => [3, 4, 5])
     end
 end


### PR DESCRIPTION
Closes #55 

Alternative to #60 (closed)

This circumvents #55 altogether by returning the same type of output for a given input.
Right now this is guaranteed for  `AbstractArray` but _not_ for Tables. So to me it makes sense to actually support this rather than continuing to special-case tables and then special-casing what `cols` does (++complexity, ++inconsistency).

We were against this initially because we didn't want to come up with a naming scheme for the returned Table.
However, [`Tables.table`](https://tables.juliadata.org/stable/#Tables.table) allows for default `headers` which seem perfectly reasonable for us to extend as part of supporting Tables. We could even expose this kwarg to the user so they can pass in their own `header` names if they want.

Furthermore, we can reconstruct the original input type thanks to [`Tables.materializer`](https://tables.juliadata.org/stable/#Tables.materializer) (thanks @morris25 for bringing my attention to this!) which makes this much easier and is actually intended precisely for this purpose in applying transformations:

```
For a table input, return the "sink" function or "materializing" function that can take a Tables.jl-compatible table input 
and make an instance of the table type. This enables "transform" workflows that take table inputs, apply transformations, 
potentially converting the table to a different form, and end with producing a table of the same type as the original input. 
The default materializer is Tables.columntable, which converts any table input into a NamedTuple of Vectors.
```

Benchmarking: note that it's less performant than main probably because we are constructing Tables, but at least it's type-stable.
```julia
julia> using DataFrames, FeatureTransforms
[ Info: Precompiling FeatureTransforms [8fd68953-04b8-4117-ac19-158bf6de9782]

julia> df = DataFrame(rand(100, 100));

julia> p = Power(3);

# main
julia> @time FeatureTransforms.apply(df, p, cols=[:x1]);
  0.153022 seconds (399.12 k allocations: 21.648 MiB)
  0.000019 seconds (8 allocations: 1.203 KiB)

julia> @time FeatureTransforms.apply(df, p, cols=:x1);
  0.006716 seconds (7.00 k allocations: 427.577 KiB)
  0.000011 seconds (5 allocations: 992 bytes)

# this branch
julia> @time FeatureTransforms.apply(df, p, cols=[:x1]);
  0.398376 seconds (1.29 M allocations: 68.336 MiB, 18.14% gc time)
  0.000036 seconds (35 allocations: 5.328 KiB)

julia> @time FeatureTransforms.apply(df, p, cols=:x1);
  0.012736 seconds (8.49 k allocations: 513.706 KiB)
  0.000043 seconds (34 allocations: 5.234 KiB)

julia> @code_warntype FeatureTransforms.apply(df, p, cols=:a)
Variables
  #unused#::Core.Compiler.Const(FeatureTransforms.var"#apply##kw"(), false)
  @_2::NamedTuple{(:cols,),Tuple{Symbol}}
  @_3::Core.Compiler.Const(FeatureTransforms.apply, false)
  table::DataFrame
  t::Power
  kwargs...::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}
  cols::Symbol
  @_8::Symbol

Body::DataFrame
1 ─       Core.NewvarNode(:(kwargs...))
│   %2  = Base.haskey(@_2, :cols)::Core.Compiler.Const(true, false)
│         %2
│         (@_8 = Base.getindex(@_2, :cols))
└──       goto #3
2 ─       Core.Compiler.Const(:(@_8 = FeatureTransforms.nothing), false)
3 ┄       (cols = @_8)
│   %8  = (:cols,)::Core.Compiler.Const((:cols,), false)
│   %9  = Core.apply_type(Core.NamedTuple, %8)::Core.Compiler.Const(NamedTuple{(:cols,),T} where T<:Tuple, false)
│   %10 = Base.structdiff(@_2, %9)::Core.Compiler.Const(NamedTuple(), false)
│         (kwargs... = Base.pairs(%10))
│   %12 = FeatureTransforms.:(var"#apply#4")(cols, kwargs..., @_3, table, t)::DataFrame
└──       return %12

```