### PR TITLE
Test on dimnames for KeyedArrays

### DIFF
--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -143,11 +143,13 @@
 
             @testset "dims = 1" begin
                 @test FeatureTransforms.apply(A, lc; dims=1) == [-3, -3]
+                @test FeatureTransforms.apply(A, lc; dims=:foo) == [-3, -3]
                 @test lc(A; dims=1) == [-3, -3]
             end
 
             @testset "dims = 2" begin
                 @test FeatureTransforms.apply(A, lc; dims=2) == [-1, -1]
+                @test FeatureTransforms.apply(A, lc; dims=:bar) == [-1, -1]
                 @test lc(A; dims=2) == [-1, -1]
             end
         end

--- a/test/one_hot_encoding.jl
+++ b/test/one_hot_encoding.jl
@@ -101,7 +101,7 @@
         A = KeyedArray(M, foo=["a", "b"], bar=["x", "y"])
         expected = [1 0 0 0 0; 0 0 0 1 0; 0 1 0 0 0; 0 0 0 0 1]
 
-        @testset "dims = $d" for d in (1, 2, Colon())
+        @testset "dims = $d" for d in (1, 2, Colon(), :foo, :bar)
             transformed = FeatureTransforms.apply(A, ohe; dims=d)
             # This transform doesn't preserve the type it operates on
             @test transformed isa AbstractArray

--- a/test/periodic.jl
+++ b/test/periodic.jl
@@ -351,7 +351,7 @@
                     bar=["x", "y"]
                 )
 
-                @testset "dims = $d" for d in (Colon(), :foo, :bar)
+                @testset "dims = $d" for d in (Colon(), :foo, :bar, 1, 2)
                     transformed = FeatureTransforms.apply(A, p; dims=d)
                     @test transformed isa KeyedArray
                     @test transformed ≈ expected atol=1e-14

--- a/test/power.jl
+++ b/test/power.jl
@@ -74,7 +74,7 @@
         A = KeyedArray([1 2 3; 4 5 6], foo=["a", "b"], bar=["x", "y", "z"])
         expected = KeyedArray([1 8 27; 64 125 216], foo=["a", "b"], bar=["x", "y", "z"])
 
-        @testset "dims = $d" for d in (Colon(), :foo, :bar)
+        @testset "dims = $d" for d in (Colon(), :foo, :bar, 1, 2)
             transformed = FeatureTransforms.apply(A, p; dims=d)
             @test transformed isa KeyedArray
             @test transformed == expected

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -412,19 +412,9 @@
                 @test _A ≈ A_expected atol=1e-5
             end
 
-            @testset "dims = :" begin
-                scaling = MeanStdScaling(A, dims=:)
-                @test FeatureTransforms.apply(A, scaling; dims=:) ≈ A_expected atol=1e-5
-            end
-
-            @testset "dims = 1" begin
-                scaling = MeanStdScaling(A; dims=1)
-                @test FeatureTransforms.apply(A, scaling; dims=1) ≈ A_expected atol=1e-5
-            end
-
-            @testset "dims = 2" begin
-                scaling = MeanStdScaling(A; dims=2)
-                @test FeatureTransforms.apply(A, scaling; dims=2) ≈ A_expected atol=1e-5
+            @testset "dims = $d" for d in (Colon(), 1, 2, :foo, :bar)
+                scaling = MeanStdScaling(A, dims=d)
+                @test FeatureTransforms.apply(A, scaling; dims=d) ≈ A_expected atol=1e-5
             end
 
             @testset "inds" begin
@@ -432,11 +422,23 @@
                 @test FeatureTransforms.apply(A, scaling; inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
                 @test FeatureTransforms.apply(A, scaling; dims=:, inds=[2, 3]) ≈ [-0.559017, -1.11803] atol=1e-5
 
-                scaling = MeanStdScaling(A; dims=1, inds=[2])
-                @test FeatureTransforms.apply(A, scaling; dims=1, inds=[2]) ≈ [-1.0 0.0 1.0] atol=1e-5
+                @testset "dims=$d" for d in (1, :foo)
+                    scaling = MeanStdScaling(A; dims=d, inds=[2])
+                    @test isapprox(
+                        FeatureTransforms.apply(A, scaling; dims=d, inds=[2]),
+                        [-1.0 0.0 1.0],
+                        atol=1e-5
+                    )
+                end
 
-                scaling = MeanStdScaling(A; dims=2, inds=[2])
-                @test FeatureTransforms.apply(A, scaling; dims=2, inds=[2]) ≈ [-0.70711 0.70711]' atol=1e-5
+                @testset "dims=$d" for d in (2, :bar)
+                    scaling = MeanStdScaling(A; dims=2, inds=[2])
+                    @test isapprox(
+                        FeatureTransforms.apply(A, scaling; dims=2, inds=[2]),
+                        [-0.70711 0.70711]',
+                        atol=1e-5
+                    )
+                end
             end
 
             @testset "Re-apply" begin

--- a/test/temporal.jl
+++ b/test/temporal.jl
@@ -114,7 +114,7 @@
         @test FeatureTransforms.apply(A, hod) == expected
         @test hod(A) == expected
 
-        @testset "dims = $d" for d in (Colon(), 1, 2)
+        @testset "dims = $d" for d in (Colon(), 1, 2, :foo, :bar)
             transformed = FeatureTransforms.apply(A, hod; dims=d)
             @test transformed isa KeyedArray
             @test transformed == expected
@@ -125,6 +125,8 @@
             @test FeatureTransforms.apply(A, hod; dims=:, inds=[2, 3]) == [2, 9]
             @test FeatureTransforms.apply(A, hod; dims=1, inds=[2]) == [2 10 12]
             @test FeatureTransforms.apply(A, hod; dims=2, inds=[2]) == reshape([9, 10], 2, 1)
+            @test FeatureTransforms.apply(A, hod; dims=:foo, inds=[2]) == [2 10 12]
+            @test FeatureTransforms.apply(A, hod; dims=:bar, inds=[2]) == reshape([9, 10], 2, 1)
         end
     end
 


### PR DESCRIPTION
Closes #20 

I'll note that #20 describes the situation before we deprecated both `eachslice` (https://github.com/invenia/FeatureTransforms.jl/pull/15) and `mapslices` (https://github.com/invenia/FeatureTransforms.jl/pull/45) in the parent `apply` methods. So the problem it is describing is outdated since we no longer need to take the complement set of dimensions for any transformations.

Still it is important that we support `dimnames` since user feedback [suggested](https://github.com/invenia/FeatureTransforms.jl/issues/20#issuecomment-801334106) "Not having named dims limits the usefulness of using a KeyedArray as opposed to just an AbstractArray". Fortunately, we already support this, this PR is just making that explicit via the tests.

However
* You can't pass in the keys as `inds` (for now, we might support this in future)
* This doesn't work with AxisArrays, at least not without `AxisArrays` first supporting `selectdim`. Considering we failed to get [`mapslices`](https://github.com/JuliaArrays/AxisArrays.jl/pull/195) into AxisArrays I'm not in a rush to support it as we'll be dropping it internally altogether soon enough.