### PR TITLE
Clean up tables code

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -82,9 +82,6 @@ function apply(table, t::Transform; cols=_get_cols(table), kwargs...)
     return Tables.materializer(table)(_to_table(result, header))
 end
 
-_to_table(x, ::Nothing) = Tables.table(x)
-_to_table(x, header) = Tables.table(x, header=header)
-
 """
     apply!(table::T, ::Transform; [cols])::T where T
 
@@ -105,5 +102,3 @@ function apply!(table::T, t::Transform; cols=_get_cols(table), kwargs...)::T whe
 
     return table
 end
-
-_get_cols(table) = propertynames(Tables.columns(table))

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -69,7 +69,7 @@ If no `cols` are specified, then the [`Transform`](@ref) is applied to all colum
 Optionally provide a `header` for the output table. If none is provided the default in
 `Tables.table` is used.
 """
-function apply(table, t::Transform; cols=_get_cols(table), kwargs...)
+function apply(table, t::Transform; cols=_get_cols(table), header=nothing, kwargs...)
     Tables.istable(table) || throw(MethodError(apply, (table, t)))
 
     # Extract a columns iterator that we should be able to use to mutate the data.
@@ -78,7 +78,6 @@ function apply(table, t::Transform; cols=_get_cols(table), kwargs...)
     cols = _to_vec(cols)
 
     result = reduce(hcat, [_apply(getproperty(coltable, col), t; kwargs...) for col in cols])
-    header = get(kwargs, :header, nothing)
     return Tables.materializer(table)(_to_table(result, header))
 end
 

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -38,7 +38,7 @@ are specified, then the [`LinearCombination`](@ref) is applied to all columns.
 Optionally provide a `header` for the output table. If none is provided the default in
 `Tables.table` is used.
 """
-function apply(table, LC::LinearCombination; cols=_get_cols(table), kwargs...)
+function apply(table, LC::LinearCombination; cols=_get_cols(table), header=nothing, kwargs...)
     Tables.istable(table) || throw(MethodError(apply, (table, LC)))
 
     # Extract a columns iterator that we should be able to use to mutate the data.
@@ -47,7 +47,6 @@ function apply(table, LC::LinearCombination; cols=_get_cols(table), kwargs...)
     cols = _to_vec(cols)
 
     result = hcat(_sum_terms([getproperty(coltable, col) for col in cols], LC.coefficients))
-    header = get(kwargs, :header, nothing)
     return Tables.materializer(table)(_to_table(result, header))
 end
 

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -52,6 +52,7 @@ function apply(table, LC::LinearCombination; cols=_get_cols(table), kwargs...)
 end
 
 function _sum_terms(terms, coeffs)
+    # Need this check because map will work even if there are more/less terms than coeffs
     if length(terms) != length(coeffs)
         throw(DimensionMismatch(
             "Number of terms $(length(terms)) does not match "*

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,5 +5,5 @@ _to_vec(x) = [x]
 
 _get_cols(table) = propertynames(Tables.columns(table))
 
-_to_table(x, ::Nothing) = Tables.table(x)
+_to_table(x, ::Nothing) = Tables.table(x)  # so that we use the defaults in Tables.table
 _to_table(x, header) = Tables.table(x, header=header)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,9 @@
-
 _to_vec(x::AbstractArray) = x
 _to_vec(x::Tuple) = x
 _to_vec(x::Nothing) = x
 _to_vec(x) = [x]
+
+_get_cols(table) = propertynames(Tables.columns(table))
+
+_to_table(x, ::Nothing) = Tables.table(x)
+_to_table(x, header) = Tables.table(x, header=header)

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -15,7 +15,7 @@
             x = [1, 2]
             lc = LinearCombination([1, -1])
             @test FeatureTransforms.apply(x, lc; dims=1) == fill(-1)
-            @test_throws DimensionMismatch FeatureTransforms.apply(x, lc; dims=2)
+            @test_throws BoundsError FeatureTransforms.apply(x, lc; dims=2)
         end
 
         @testset "dimension mismatch" begin


### PR DESCRIPTION
After #61 I thought it would be good to refactor / clean up as the code was getting a bit messy.

* simplifying the `apply(table, ...)` methods
* removing the 3-arg `apply` methods
* refactoring the linear combination `_sum_row` method to only perform it once for all the cols instead of for every row.

This also comes with some more performance boosts - especially for `LinearCombination` 
```julia
julia> using DataFrames, FeatureTransforms

julia> p = Power(3);

julia> df = DataFrame(rand(100, 100));

# this branch
julia> @time FeatureTransforms.apply(df, p);
  0.542554 seconds (1.74 M allocations: 91.461 MiB, 4.43% gc time)
  0.000439 seconds (1.06 k allocations: 317.812 KiB)

# main
julia> @time FeatureTransforms.apply(df, p);
  0.365457 seconds (1.37 M allocations: 76.569 MiB, 6.15% gc time)
  0.002109 seconds (1.52 k allocations: 4.178 MiB)

# this branch
julia> @time FeatureTransforms.apply(df, p, cols=:x1);
  0.020192 seconds (47.53 k allocations: 2.830 MiB)
  0.000131 seconds (53 allocations: 11.609 KiB)

# main
julia> @time FeatureTransforms.apply(df, p, cols=:x1);
  0.010885 seconds (8.50 k allocations: 513.378 KiB)
  0.000043 seconds (34 allocations: 5.234 KiB)

julia> lc = LinearCombination(ones(100));

# this branch
julia> @time FeatureTransforms.apply(df, lc);
  0.300694 seconds (1.21 M allocations: 63.126 MiB, 3.88% gc time)
  0.000259 seconds (751 allocations: 199.766 KiB)

# main
julia> @time FeatureTransforms.apply(df, lc);
  0.204158 seconds (708.95 k allocations: 34.896 MiB, 6.52% gc time)
  0.003044 seconds (50.54 k allocations: 1.179 MiB)

julia> lc = LinearCombination(ones(5));

# this branch
julia> @time FeatureTransforms.apply(df, lc, cols=[:x1, :x2, :x3, :x4, :x5]);
  0.005228 seconds (4.03 k allocations: 266.237 KiB)
  0.000144 seconds (87 allocations: 19.406 KiB)

# main
julia> @time FeatureTransforms.apply(df, lc, cols=[:x1, :x2, :x3, :x4, :x5]);
  0.155136 seconds (394.81 k allocations: 19.945 MiB, 7.72% gc time)
  0.000211 seconds (2.94 k allocations: 102.297 KiB)