### PR TITLE
POC: Add traits to support generalising the apply methods

### DIFF
--- a/src/FeatureTransforms.jl
+++ b/src/FeatureTransforms.jl
@@ -14,7 +14,6 @@ include("utils.jl")
 include("traits.jl")
 include("transform.jl")
 include("apply.jl")
-include("test_utils.jl")
 
 # Transform implementations
 include("linear_combination.jl")
@@ -23,5 +22,7 @@ include("periodic.jl")
 include("power.jl")
 include("scaling.jl")
 include("temporal.jl")
+
+include("test_utils.jl")
 
 end

--- a/src/FeatureTransforms.jl
+++ b/src/FeatureTransforms.jl
@@ -14,6 +14,7 @@ include("utils.jl")
 include("traits.jl")
 include("transform.jl")
 include("apply.jl")
+include("test_utils.jl")
 
 # Transform implementations
 include("linear_combination.jl")

--- a/src/FeatureTransforms.jl
+++ b/src/FeatureTransforms.jl
@@ -11,6 +11,7 @@ export Transform
 export is_transformable, transform, transform!
 
 include("utils.jl")
+include("traits.jl")
 include("transform.jl")
 include("apply.jl")
 

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -35,15 +35,17 @@ Note: if `dims === :` (all dimensions), then `inds` will be the global indices o
 instead of being relative to a certain dimension.
 """
 function apply(A::AbstractArray, t::Transform; dims=:, inds=:, kwargs...)
+    c = cardinality(t)
     if dims === Colon()
         if inds === Colon()
-            return _apply(_preformat(cardinality(t), A, :), t; dims=:, kwargs...)
+            return _apply(_preformat(c, A, :), t; dims=:, kwargs...)
         else
-            return _apply(_preformat(cardinality(t), A[:][inds], :), t; dims=:, kwargs...)
+            return _apply(_preformat(c, A[:][inds], :), t; dims=:, kwargs...)
         end
     end
 
-    return _apply(_preformat(cardinality(t), selectdim(A, dims, inds), dims), t; dims=dims, kwargs...)
+    input = _preformat(c, selectdim(A, dims, inds), dims)
+    return _apply(input, t; dims=dims, kwargs...)
 end
 
 """
@@ -75,7 +77,8 @@ function apply(table, t::Transform; cols=_get_cols(table), header=nothing, kwarg
 
     # We call hcat to convert any Vector components/results into a Matrix.
     # Passing dims=2 only matters for ManyToOne transforms - otherwise it has no effect.
-    result = hcat(_apply(_preformat(cardinality(t), hcat(components), 2), t; dims=2, kwargs...))
+    input = _preformat(cardinality(t), hcat(components), 2)
+    result = hcat(_apply(input, t; dims=2, kwargs...))
     return Tables.materializer(table)(_to_table(result, header))
 end
 

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -7,6 +7,8 @@ struct LinearCombination <: Transform
     coefficients::Vector{Real}
 end
 
+cardinality(::LinearCombination) = ManyToOne()
+
 """
     apply(
         ::AbstractArray{<:Real, N}, ::LinearCombination; dims=1, inds=:

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -9,64 +9,14 @@ end
 
 cardinality(::LinearCombination) = ManyToOne()
 
-"""
-    apply(
-        ::AbstractArray{<:Real, N}, ::LinearCombination; dims=1, inds=:
-    ) -> AbstractArray{<:Real, N-1}
-
-Applies the [`LinearCombination`](@ref) to each of the specified indices in the N-dimensional
-array `A`, reducing along the `dim` provided. The result is an (N-1)-dimensional array.
-
-The default behaviour reduces along the column dimension.
-
-If no `inds` are specified, then the transform is applied to all elements.
-"""
-function apply(
-    A::AbstractArray{<:Real, N}, LC::LinearCombination; dims=1, inds=:
-)::AbstractArray{<:Real, N-1} where N
-
-    dims === Colon() && throw(ArgumentError("dims=: not supported, choose dims ∈ [1, $N]"))
-
-    return _sum_terms(eachslice(selectdim(A, dims, inds); dims=dims), LC.coefficients)
-end
-
-"""
-    apply(table, LC::LinearCombination; [cols], [header]) -> Table
-
-Applies the [`LinearCombination`](@ref) across the specified cols in `table`. If no `cols`
-are specified, then the [`LinearCombination`](@ref) is applied to all columns.
-
-Optionally provide a `header` for the output table. If none is provided the default in
-`Tables.table` is used.
-"""
-function apply(table, LC::LinearCombination; cols=_get_cols(table), header=nothing, kwargs...)
-    Tables.istable(table) || throw(MethodError(apply, (table, LC)))
-
-    # Extract a columns iterator that we should be able to use to mutate the data.
-    # NOTE: Mutation is not guaranteed for all table types, but it avoid copying the data
-    coltable = Tables.columntable(table)
-    cols = _to_vec(cols)
-
-    result = hcat(_sum_terms([getproperty(coltable, col) for col in cols], LC.coefficients))
-    return Tables.materializer(table)(_to_table(result, header))
-end
-
-function apply_append(
-    A::AbstractArray{<:Real, N}, LC::LinearCombination; append_dim, kwargs...
-)::AbstractArray{<:Real, N} where N
-    # A was reduced along the append_dim so we must reshape the result setting that dim to 1
-    new_size = collect(size(A))
-    setindex!(new_size, 1, dim(A, append_dim))
-    return cat(A, reshape(apply(A, LC; kwargs...), new_size...); dims=append_dim)
-end
-
-function _sum_terms(terms, coeffs)
+function _apply(terms, LC::LinearCombination; kwargs...)
     # Need this check because map will work even if there are more/less terms than coeffs
-    if length(terms) != length(coeffs)
+    if length(terms) != length(LC.coefficients)
         throw(DimensionMismatch(
             "Number of terms $(length(terms)) does not match "*
-            "number of coefficients $(length(coeffs))."
+            "number of coefficients $(length(LC.coefficients))."
         ))
     end
-   return sum(map(*, terms, coeffs))
+
+   return sum(map(*, terms, LC.coefficients))
 end

--- a/src/one_hot_encoding.jl
+++ b/src/one_hot_encoding.jl
@@ -32,6 +32,8 @@ struct OneHotEncoding{R<:Real} <: Transform
     end
 end
 
+cardinality(::OneHotEncoding) = OneToMany()
+
 function OneHotEncoding(possible_values::AbstractVector{T}) where T
     return OneHotEncoding{Bool}(possible_values)
 end

--- a/src/periodic.jl
+++ b/src/periodic.jl
@@ -33,6 +33,8 @@ struct Periodic{P, S} <: Transform
     end
 end
 
+cardinality(::Periodic) = OneToOne()
+
 """
     Periodic(f, period) -> Periodic
 

--- a/src/power.jl
+++ b/src/power.jl
@@ -7,4 +7,6 @@ struct Power <: Transform
     exponent::Real
 end
 
+cardinality(::Power) = OneToOne()
+
 _apply(x, P::Power; kwargs...) = x .^ P.exponent

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -12,6 +12,8 @@ Represents the no-op scaling which simply returns the `data` it is applied on.
 """
 struct IdentityScaling <: AbstractScaling end
 
+cardinality(::IdentityScaling) = OneToOne()
+
 @inline _apply(x, ::IdentityScaling; kwargs...) = x
 
 """
@@ -67,6 +69,8 @@ struct MeanStdScaling <: AbstractScaling
 end
 
 compute_stats(x) = (mean(x), std(x))
+
+cardinality(::MeanStdScaling) = OneToOne()
 
 function _apply(A::AbstractArray, scaling::MeanStdScaling; inverse=false, eps=1e-3, kwargs...)
     inverse && return scaling.μ .+ scaling.σ .* A

--- a/src/temporal.jl
+++ b/src/temporal.jl
@@ -4,5 +4,6 @@
 Get the hour of day corresponding to the data.
 """
 struct HoD <: Transform end
+cardinality(::HoD) = OneToOne()
 
 _apply(x, ::HoD; kwargs...) = hour.(x)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1,0 +1,25 @@
+module TestUtils
+
+using ..FeatureTransforms
+using ..FeatureTransforms: OneToOne, OneToMany, ManyToOne, ManyToMany
+
+export FakeOneToOneTransform, FakeOneToManyTransform
+export FakeManyToOneTransform, FakeManyToManyTransform
+
+struct FakeOneToOneTransform <: Transform end
+FeatureTransforms.cardinality(::FakeOneToOneTransform) = OneToOne()
+FeatureTransforms._apply(A, ::FakeOneToOneTransform; kwargs...) = ones(size(A))
+
+struct FakeOneToManyTransform <: Transform end
+FeatureTransforms.cardinality(::FakeOneToManyTransform) = OneToMany()
+FeatureTransforms._apply(A, ::FakeOneToManyTransform; kwargs...) = hcat(ones(size(A)), ones(size(A)))
+
+struct FakeManyToOneTransform <: Transform end
+FeatureTransforms.cardinality(::FakeManyToOneTransform) = ManyToOne()
+FeatureTransforms._apply(A, ::FakeManyToOneTransform; dims, kwargs...) = ones(size(first(A)))
+
+struct FakeManyToManyTransform <: Transform end
+FeatureTransforms.cardinality(::FakeManyToManyTransform) = ManyToMany()
+FeatureTransforms._apply(A, ::FakeManyToManyTransform; kwargs...) = hcat(ones(size(A)), ones(size(A)))
+
+end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,0 +1,49 @@
+"""
+    type Cardinality
+
+A trait describing the cardinality of a [`Transform`]
+[`OneToOne`](@ref), [`ManyToOne`](@ref), [`OneToMany`](@ref), and [`ManyToMany`](@ref).
+"""
+
+abstract type Cardinality end
+
+"""
+    OneToOne <: Cardinality
+
+Transforms that map each input to exactly one output: `x → y`.
+Examples: [`Power`](@ref), [`Periodic`](@ref).
+"""
+struct OneToOne <: Cardinality end
+
+"""
+    ManyToOne <: Cardinality
+
+Transforms that map many inputs to one output: `(x_1, x_2, ..., x_n) → y`.
+These are typically reduction operations.
+Examples: [`LinearCombination`](@ref).
+"""
+struct ManyToOne <: Cardinality end
+
+"""
+    OneToMany <: Cardinality
+
+Transforms that map one input to many outputs: `x → (y_1, y_2, ..., y_n)`.
+Examples: [`OneHotEncoding`](@ref).
+"""
+struct OneToMany <: Cardinality end
+
+"""
+    ManyToMany <: Cardinality
+
+Transforms that map many inputs to many outputs: `(x_1, x_2, ..., x_m) → (y_1, y_2, ..., y_n)`.
+Examples: Principle Component Analysis (not implemented).
+"""
+struct ManyToMany <: Cardinality end
+
+
+"""
+    cardinality(transform) -> Cardinality
+
+Return the [`Cardinality`](@ref) of the `transform`.
+"""
+function cardinality end

--- a/test/example_test.jl
+++ b/test/example_test.jl
@@ -1,0 +1,77 @@
+# This is how we might test a new data type that we want to support.
+# For illustrative purposes this is testing DataFrames.
+
+using DataFrames
+using FeatureTransforms
+using FeatureTransforms.TestUtils
+using Test
+
+@testset "example apply tests" begin
+
+    @testset "OneToOne" begin
+        df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [7, 8, 9])
+        t = FakeOneToOneTransform()
+
+        @test isequal(
+            FeatureTransforms.apply(df, t),
+            DataFrame(ones(3, 3), [:Column1, :Column2, :Column3]),
+        )
+
+        @test isequal(
+                FeatureTransforms.apply(df, t; header=[:a, :b, :c]),
+                DataFrame(ones(3, 3), [:a, :b, :c]),
+        )
+
+        @test FeatureTransforms.apply(df, t; cols=:a) == DataFrame(:Column1 => ones(3))
+    end
+
+    @testset "OneToMany" begin
+        df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [7, 8, 9])
+        t = FakeOneToManyTransform()
+
+        @test isequal(
+            FeatureTransforms.apply(df, t),
+            DataFrame(ones(3, 6), [:Column1, :Column2, :Column3, :Column4, :Column5, :Column6]),
+        )
+
+        @test isequal(
+            FeatureTransforms.apply(df, t; header=[:a, :b, :c, :d, :e, :f]),
+            DataFrame(ones(3, 6), [:a, :b, :c, :d, :e, :f]),
+        )
+
+        @test isequal(
+            FeatureTransforms.apply(df, t, cols=:a),
+            DataFrame(ones(3, 2), [:Column1, :Column2]),
+        )
+    end
+
+    @testset "ManyToOne" begin
+        df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [7, 8, 9])
+        t = FakeManyToOneTransform()
+
+        @test isequal(FeatureTransforms.apply(df, t), DataFrame(:Column1 => ones(3)))
+        @test isequal(FeatureTransforms.apply(df, t; header=[:a]), DataFrame(:a => ones(3)))
+        @test isequal(FeatureTransforms.apply(df, t; cols=:a), DataFrame(:Column1 => ones(3)))
+    end
+
+    @testset "ManyToMany" begin
+        df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [7, 8, 9])
+        t = FakeManyToManyTransform()
+
+        @test isequal(
+            FeatureTransforms.apply(df, t),
+            DataFrame(ones(3, 6), [:Column1, :Column2, :Column3, :Column4, :Column5, :Column6]),
+        )
+
+        @test isequal(
+            FeatureTransforms.apply(df, t; header=[:a, :b, :c, :d, :e, :f]),
+            DataFrame(ones(3, 6), [:a, :b, :c, :d, :e, :f]),
+        )
+
+        @test isequal(
+            FeatureTransforms.apply(df, t, cols=:a),
+            DataFrame(ones(3, 2), [:Column1, :Column2]),
+        )
+    end
+
+end

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -7,8 +7,8 @@
         @testset "all inds" begin
             x = [1, 2]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(x, lc) == fill(-1)
-            @test lc(x) == fill(-1)
+            @test FeatureTransforms.apply(x, lc; dims=1) == fill(-1)
+            @test lc(x; dims=1) == fill(-1)
         end
 
         @testset "dims behaviour" begin
@@ -21,44 +21,36 @@
         @testset "dimension mismatch" begin
             x = [1, 2, 3]
             lc = LinearCombination([1, -1])
-            @test_throws DimensionMismatch FeatureTransforms.apply(x, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(x, lc, dims=1)
         end
 
         @testset "specified inds" begin
             x = [1, 2, 3]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(x, lc; inds=[2, 3]) == fill(-1)
-            @test lc(x; inds=[2, 3]) == fill(-1)
+            @test FeatureTransforms.apply(x, lc; dims=1, inds=[2, 3]) == fill(-1)
+            @test lc(x; dims=1, inds=[2, 3]) == fill(-1)
         end
 
         @testset "output is different type" begin
             x = [1, 2]
             lc = LinearCombination([.1, -.1])
-            @test FeatureTransforms.apply(x, lc) == fill(-.1)
-            @test lc(x) == fill(-.1)
+            @test FeatureTransforms.apply(x, lc, dims=1) == fill(-.1)
+            @test lc(x; dims=1) == fill(-.1)
         end
 
         @testset "apply_append" begin
             x = [1, 2]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply_append(x, lc; append_dim=1) == [1, 2, -1]
+            @test FeatureTransforms.apply_append(x, lc; dims=1, append_dim=1) == [1, 2, -1]
         end
     end
 
     @testset "Matrix" begin
-
-        @testset "default reduces over columns" begin
-            M = [1 1; 2 2; 3 5]
-            lc = LinearCombination([1, -1, 1])
-            @test FeatureTransforms.apply(M, lc) == [2, 4]
-            @test lc(M) == [2, 4]
-        end
-
         @testset "dims" begin
             @testset "dims = :" begin
                 M = [1 1; 2 2; 3 5]
                 lc = LinearCombination([1, -1, 1])
-                @test_throws ArgumentError FeatureTransforms.apply(M, lc; dims=:)
+                @test_throws MethodError FeatureTransforms.apply(M, lc; dims=:)
             end
 
             @testset "dims = 1" begin
@@ -78,14 +70,14 @@
         @testset "dimension mismatch" begin
             M = [1 1 1; 2 2 2]
             lc = LinearCombination([1, -1, 1])  # there are only 2 rows
-            @test_throws DimensionMismatch FeatureTransforms.apply(M, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(M, lc; dims=1)
         end
 
         @testset "specified inds" begin
             M = [1 1; 5 2; 2 4]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(M, lc; inds=[2, 3]) == [3, -2]
-            @test lc(M; inds=[2, 3]) == [3, -2]
+            @test FeatureTransforms.apply(M, lc; dims=1, inds=[2, 3]) == [3, -2]
+            @test lc(M; dims=1, inds=[2, 3]) == [3, -2]
         end
 
         @testset "apply_append" begin
@@ -103,8 +95,8 @@
     @testset "N-dim Array" begin
         A = reshape(1:27, 3, 3, 3)
         lc = LinearCombination([1, -1, 1])
-        @test FeatureTransforms.apply(A, lc) == [2 11 20; 5 14 23; 8 17 26]
-        @test lc(A) == [2 11 20; 5 14 23; 8 17 26]
+        @test FeatureTransforms.apply(A, lc; dims=1) == [2 11 20; 5 14 23; 8 17 26]
+        @test lc(A; dims=1) == [2 11 20; 5 14 23; 8 17 26]
     end
 
     @testset "AxisArray" begin
@@ -112,13 +104,13 @@
         lc = LinearCombination([1, -1])
 
         @testset "all inds" begin
-            @test FeatureTransforms.apply(A, lc) == [-3, -3]
-            @test lc(A) == [-3, -3]
+            @test FeatureTransforms.apply(A, lc; dims=1) == [-3, -3]
+            @test lc(A; dims=1) == [-3, -3]
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
-                @test_throws ArgumentError FeatureTransforms.apply(A, lc; dims=:)
+                @test_throws MethodError FeatureTransforms.apply(A, lc; dims=:)
             end
 
             @testset "dims = 1" begin
@@ -139,8 +131,8 @@
 
         @testset "specified inds" begin
             A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            @test FeatureTransforms.apply(A, lc; inds=[1, 2]) == [-3, -3, -2]
-            @test lc(A; inds=[1, 2]) == [-3, -3, -2]
+            @test FeatureTransforms.apply(A, lc; dims=1, inds=[1, 2]) == [-3, -3, -2]
+            @test lc(A; dims=1, inds=[1, 2]) == [-3, -3, -2]
         end
 
         @testset "apply_append" begin
@@ -159,13 +151,13 @@
         lc = LinearCombination([1, -1])
 
         @testset "all inds" begin
-            @test FeatureTransforms.apply(A, lc) == [-3, -3]
-            @test lc(A) == [-3, -3]
+            @test FeatureTransforms.apply(A, lc; dims=1) == [-3, -3]
+            @test lc(A; dims=1) == [-3, -3]
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
-                @test_throws ArgumentError FeatureTransforms.apply(A, lc; dims=:)
+                @test_throws MethodError FeatureTransforms.apply(A, lc; dims=:)
             end
 
             @testset "dims = 1" begin
@@ -188,8 +180,8 @@
 
         @testset "specified inds" begin
             A = KeyedArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            @test FeatureTransforms.apply(A, lc; inds=[1, 2]) == [-3, -3, -2]
-            @test lc(A; inds=[1, 2]) == [-3, -3, -2]
+            @test FeatureTransforms.apply(A, lc; dims=1, inds=[1, 2]) == [-3, -3, -2]
+            @test lc(A; dims=1, inds=[1, 2]) == [-3, -3, -2]
         end
 
         @testset "apply_append" begin

--- a/test/one_hot_encoding.jl
+++ b/test/one_hot_encoding.jl
@@ -146,8 +146,8 @@
         nt = (a = ["foo", "bar"], b = ["foo2", "bar2"])
 
         @testset "all cols" begin
-            expected = NamedTuple{Tuple(Symbol.(:Column, x) for x in 1:10)}(
-               ([1, 0], [0, 1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [1, 0], [0, 1])
+            expected = NamedTuple{Tuple(Symbol.(:Column, x) for x in 1:5)}(
+               eachcol(Bool[1 0 0 0 0; 0 1 0 0 0; 0 0 0 1 0; 0 0 0 0 1])
             )
             @test FeatureTransforms.apply(nt, ohe) == expected
             @test ohe(nt) == expected
@@ -174,14 +174,14 @@
 
         df = DataFrame(:a => ["foo", "bar"], :b => ["foo2", "bar2"])
         expected = DataFrame(
-            [[1, 0], [0, 1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [1, 0], [0, 1]],
-            [Symbol.(:Column, x) for x in 1:10],
+            Bool[1 0 0 0 0; 0 1 0 0 0; 0 0 0 1 0; 0 0 0 0 1],
+            [Symbol.(:Column, x) for x in 1:5],
         )
 
         @test FeatureTransforms.apply(df, ohe) == expected
 
-        @test FeatureTransforms.apply(df, ohe; cols=[:a]) == expected[:, 1:5]
-        @test FeatureTransforms.apply(df, ohe; cols=:a) == expected[:, 1:5]
+        @test FeatureTransforms.apply(df, ohe; cols=[:a]) == expected[1:2, :]
+        @test FeatureTransforms.apply(df, ohe; cols=:a) == expected[1:2, :]
 
         expected = DataFrame(
             [[false, false], [false, false], [false, false], [true, false], [false, true]],
@@ -190,7 +190,7 @@
         @test FeatureTransforms.apply(df, ohe; cols=[:b]) == expected
 
         @testset "apply_append" begin
-            @test FeatureTransforms.apply_append(df, ohe) == hcat(df, ohe(df))
+            @test_throws DimensionMismatch FeatureTransforms.apply_append(df, ohe)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,4 +21,7 @@ using TimeZones
     include("temporal.jl")
     include("transform.jl")
     include("traits.jl")
+
+    # TODO: remove this
+    include("example_test.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Dates
 using Documenter: doctest
 using FeatureTransforms
 using FeatureTransforms: _periodic
+using FeatureTransforms: Cardinality, OneToOne, OneToMany, ManyToOne, ManyToMany
 using Test
 using TimeZones
 
@@ -19,4 +20,5 @@ using TimeZones
     include("scaling.jl")
     include("temporal.jl")
     include("transform.jl")
+    include("traits.jl")
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,0 +1,5 @@
+@testset "traits.jl" begin
+    for t in (OneToOne(), OneToMany(), ManyToOne(), ManyToMany())
+        @test t isa Cardinality
+    end
+end


### PR DESCRIPTION
POC for #75 

Some brief notes to guide review:

This started off implementing the idea in the description of #75: adding traits to describe the [cardinality](https://en.wikipedia.org/wiki/Cardinality_(data_modeling)) of our transforms and defining an intermediate `_apply` method that dispatched on the traits.

But after some refactoring at the end, I noticed that the key difference boiled down to how the data was _prepared_ before going into a `ManyToOne` transform (`LinearCombination`).

So I refactored a bit more to create two simple formatting functions:
* `_preformat` structures the input to `_apply` according to the cardinality of the transform. Effectively, this just calls `eachslice` before calling `_apply` for `LinearCombination`.
* `_preformat` structures the output of `_apply` according to the cardinality of the transform. This is really only needed for `append_apply` because `LinearCombination` returns a `Vector`, if we are appending it as a row `cat` throws a DimensionMismatch. So we have to pivot the data before doing so.

I added some `TestUtils` with `Fakes` for the above transforms and an example testset for how we might test a new data type in a more manageable way in the future.
The idea being that: once a datatype supports each type of transform (and returns correct result for the `kwargs`) then it should support _any_  of the transforms defined in the package.

Then, each transform just needs to be tested against `Array`s and nothing else, which should give us full test coverage but in a much simpler way.

 

