### PR TITLE
Add method for IdentityScaling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureTransforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -11,6 +11,7 @@ abstract type AbstractScaling <: Transform end
 Represents the no-op scaling which simply returns the `data` it is applied on.
 """
 struct IdentityScaling <: AbstractScaling end
+IdentityScaling(args...) = IdentityScaling()
 
 @inline _apply(x, ::IdentityScaling; kwargs...) = x
 

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -4,6 +4,11 @@
         scaling = IdentityScaling()
         @test scaling isa Transform
 
+        @testset "Arguments do nothing" begin
+            @test IdentityScaling(123) == IdentityScaling()
+            @test IdentityScaling([1, 2, 3]) == IdentityScaling()
+        end
+
         @testset "Vector" begin
             x = [1., 2., 3.]
             expected = [1., 2., 3.]


### PR DESCRIPTION
MeanStdScaling expects to be initialised with some data.
In downstream processes, MeanStdScaling might be swapped out for an IdentityScaling, so it needs to support the same construction, even if it does nothing.