### PR TITLE
Refactor apply methods to use Traits

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -35,6 +35,16 @@ Note: if `dims === :` (all dimensions), then `inds` will be the global indices o
 instead of being relative to a certain dimension.
 """
 function apply(A::AbstractArray, t::Transform; dims=:, inds=:, kwargs...)
+
+    if t isa LinearCombination && dims === Colon()
+        Base.depwarn(
+           "The default `dims=1` for `LinearCombination` is deprecated and will be removed " *
+           "in a future release. Please set `dims` explicitly.",
+           :apply,
+        )
+        dims=1
+    end
+
     c = cardinality(t)
     if dims === Colon()
         if inds === Colon()
@@ -128,7 +138,6 @@ function apply_append(table, t; kwargs...)
     result = Tables.columntable(apply(table, t; kwargs...))
     return T(merge(Tables.columntable(table), result))
 end
-
 
 # These methods format data according to the cardinality of the Transform.
 # Most Transforms don't require any formatting, only those that are ManyToOne do.

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -18,7 +18,6 @@ If [`Transform`](@ref) does not support mutation, this method will error.
 """
 function apply! end
 
-
 """
     apply(A::AbstractArray, ::Transform; dims=:, inds=:, kwargs...)
 
@@ -36,6 +35,7 @@ instead of being relative to a certain dimension.
 """
 function apply(A::AbstractArray, t::Transform; dims=:, inds=:, kwargs...)
 
+    # TODO: remove this in version >=0.4
     if t isa LinearCombination && dims === Colon()
         Base.depwarn(
            "The default `dims=1` for `LinearCombination` is deprecated and will be removed " *
@@ -83,7 +83,7 @@ function apply(table, t::Transform; cols=_get_cols(table), header=nothing, kwarg
     # Extract a columns iterator that we should be able to use to mutate the data.
     # NOTE: Mutation is not guaranteed for all table types, but it avoid copying the data
     coltable = Tables.columntable(table)
-    # Combine the Vector{Vector} of components into a Matrix
+    # Consolidate the Vector{Vector} components into a single array, which might be a Vector.
     components = reduce(hcat, getproperty(coltable, col) for col in _to_vec(cols))
 
     # Calling hcat converts any Vector components/results into a Matrix.

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -1,7 +1,12 @@
 """
     LinearCombination(coefficients) <: Transform
 
-Calculate the linear combination using the vector coefficients passed in.
+Calculates the linear combination of a collection of terms weighted be some `coefficients`.
+
+When applied to an N-dimensional array, `LinearCombination` reduces along the `dim` provided
+and returns an (N-1)-dimensional array.
+
+If no `inds` are specified, then the transform is applied to all elements.
 """
 struct LinearCombination <: Transform
     coefficients::Vector{Real}
@@ -9,64 +14,14 @@ end
 
 cardinality(::LinearCombination) = ManyToOne()
 
-"""
-    apply(
-        ::AbstractArray{<:Real, N}, ::LinearCombination; dims=1, inds=:
-    ) -> AbstractArray{<:Real, N-1}
-
-Applies the [`LinearCombination`](@ref) to each of the specified indices in the N-dimensional
-array `A`, reducing along the `dim` provided. The result is an (N-1)-dimensional array.
-
-The default behaviour reduces along the column dimension.
-
-If no `inds` are specified, then the transform is applied to all elements.
-"""
-function apply(
-    A::AbstractArray{<:Real, N}, LC::LinearCombination; dims=1, inds=:
-)::AbstractArray{<:Real, N-1} where N
-
-    dims === Colon() && throw(ArgumentError("dims=: not supported, choose dims ∈ [1, $N]"))
-
-    return _sum_terms(eachslice(selectdim(A, dims, inds); dims=dims), LC.coefficients)
-end
-
-"""
-    apply(table, LC::LinearCombination; [cols], [header]) -> Table
-
-Applies the [`LinearCombination`](@ref) across the specified cols in `table`. If no `cols`
-are specified, then the [`LinearCombination`](@ref) is applied to all columns.
-
-Optionally provide a `header` for the output table. If none is provided the default in
-`Tables.table` is used.
-"""
-function apply(table, LC::LinearCombination; cols=_get_cols(table), header=nothing, kwargs...)
-    Tables.istable(table) || throw(MethodError(apply, (table, LC)))
-
-    # Extract a columns iterator that we should be able to use to mutate the data.
-    # NOTE: Mutation is not guaranteed for all table types, but it avoid copying the data
-    coltable = Tables.columntable(table)
-    cols = _to_vec(cols)
-
-    result = hcat(_sum_terms([getproperty(coltable, col) for col in cols], LC.coefficients))
-    return Tables.materializer(table)(_to_table(result, header))
-end
-
-function apply_append(
-    A::AbstractArray{<:Real, N}, LC::LinearCombination; append_dim, kwargs...
-)::AbstractArray{<:Real, N} where N
-    # A was reduced along the append_dim so we must reshape the result setting that dim to 1
-    new_size = collect(size(A))
-    setindex!(new_size, 1, dim(A, append_dim))
-    return cat(A, reshape(apply(A, LC; kwargs...), new_size...); dims=append_dim)
-end
-
-function _sum_terms(terms, coeffs)
+function _apply(terms, LC::LinearCombination; kwargs...)
     # Need this check because map will work even if there are more/less terms than coeffs
-    if length(terms) != length(coeffs)
+    if length(terms) != length(LC.coefficients)
         throw(DimensionMismatch(
             "Number of terms $(length(terms)) does not match "*
-            "number of coefficients $(length(coeffs))."
+            "number of coefficients $(length(LC.coefficients))."
         ))
     end
-   return sum(map(*, terms, coeffs))
+
+   return sum(map(*, terms, LC.coefficients))
 end

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -1,12 +1,17 @@
 """
     LinearCombination(coefficients) <: Transform
 
-Calculates the linear combination of a collection of terms weighted be some `coefficients`.
+Calculates the linear combination of a collection of terms weighted by some `coefficients`.
 
 When applied to an N-dimensional array, `LinearCombination` reduces along the `dim` provided
 and returns an (N-1)-dimensional array.
 
 If no `inds` are specified, then the transform is applied to all elements.
+
+!!!note
+    The current default is that `dims=1` but this behaviour will be deprecated in a future
+    release and the `dims` keyword argument will have to be specified explicitly.
+    https://github.com/invenia/FeatureTransforms.jl/issues/82
 """
 struct LinearCombination <: Transform
     coefficients::Vector{Real}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 _to_vec(x::AbstractArray) = x
-_to_vec(x::Tuple) = x
+_to_vec(x::Tuple) = collect(x)
 _to_vec(x::Nothing) = x
 _to_vec(x) = [x]
 

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -9,8 +9,8 @@
         @testset "all inds" begin
             x = [1, 2]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(x, lc; dims=1) == fill(-1)
-            @test lc(x; dims=1) == fill(-1)
+            @test FeatureTransforms.apply(x, lc) == fill(-1)
+            @test lc(x) == fill(-1)
         end
 
         @testset "dims behaviour" begin
@@ -23,36 +23,44 @@
         @testset "dimension mismatch" begin
             x = [1, 2, 3]
             lc = LinearCombination([1, -1])
-            @test_throws DimensionMismatch FeatureTransforms.apply(x, lc, dims=1)
+            @test_throws DimensionMismatch FeatureTransforms.apply(x, lc)
         end
 
         @testset "specified inds" begin
             x = [1, 2, 3]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(x, lc; dims=1, inds=[2, 3]) == fill(-1)
-            @test lc(x; dims=1, inds=[2, 3]) == fill(-1)
+            @test FeatureTransforms.apply(x, lc; inds=[2, 3]) == fill(-1)
+            @test lc(x; inds=[2, 3]) == fill(-1)
         end
 
         @testset "output is different type" begin
             x = [1, 2]
             lc = LinearCombination([.1, -.1])
-            @test FeatureTransforms.apply(x, lc, dims=1) == fill(-.1)
-            @test lc(x; dims=1) == fill(-.1)
+            @test FeatureTransforms.apply(x, lc) == fill(-.1)
+            @test lc(x) == fill(-.1)
         end
 
         @testset "apply_append" begin
             x = [1, 2]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply_append(x, lc; dims=1, append_dim=1) == [1, 2, -1]
+            @test FeatureTransforms.apply_append(x, lc; append_dim=1) == [1, 2, -1]
         end
     end
 
     @testset "Matrix" begin
+
+        @testset "default reduces over columns" begin
+            M = [1 1; 2 2; 3 5]
+            lc = LinearCombination([1, -1, 1])
+            @test FeatureTransforms.apply(M, lc) == [2, 4]
+            @test lc(M) == [2, 4]
+        end
+
         @testset "dims" begin
             @testset "dims = :" begin
                 M = [1 1; 2 2; 3 5]
                 lc = LinearCombination([1, -1, 1])
-                @test_throws MethodError FeatureTransforms.apply(M, lc; dims=:)
+                @test_deprecated FeatureTransforms.apply(M, lc; dims=:)
             end
 
             @testset "dims = 1" begin
@@ -72,14 +80,14 @@
         @testset "dimension mismatch" begin
             M = [1 1 1; 2 2 2]
             lc = LinearCombination([1, -1, 1])  # there are only 2 rows
-            @test_throws DimensionMismatch FeatureTransforms.apply(M, lc; dims=1)
+            @test_throws DimensionMismatch FeatureTransforms.apply(M, lc)
         end
 
         @testset "specified inds" begin
             M = [1 1; 5 2; 2 4]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(M, lc; dims=1, inds=[2, 3]) == [3, -2]
-            @test lc(M; dims=1, inds=[2, 3]) == [3, -2]
+            @test FeatureTransforms.apply(M, lc; inds=[2, 3]) == [3, -2]
+            @test lc(M; inds=[2, 3]) == [3, -2]
         end
 
         @testset "apply_append" begin
@@ -97,8 +105,8 @@
     @testset "N-dim Array" begin
         A = reshape(1:27, 3, 3, 3)
         lc = LinearCombination([1, -1, 1])
-        @test FeatureTransforms.apply(A, lc; dims=1) == [2 11 20; 5 14 23; 8 17 26]
-        @test lc(A; dims=1) == [2 11 20; 5 14 23; 8 17 26]
+        @test FeatureTransforms.apply(A, lc) == [2 11 20; 5 14 23; 8 17 26]
+        @test lc(A) == [2 11 20; 5 14 23; 8 17 26]
     end
 
     @testset "AxisArray" begin
@@ -106,13 +114,13 @@
         lc = LinearCombination([1, -1])
 
         @testset "all inds" begin
-            @test FeatureTransforms.apply(A, lc; dims=1) == [-3, -3]
-            @test lc(A; dims=1) == [-3, -3]
+            @test FeatureTransforms.apply(A, lc) == [-3, -3]
+            @test lc(A) == [-3, -3]
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
-                @test_throws MethodError FeatureTransforms.apply(A, lc; dims=:)
+                @test_deprecated FeatureTransforms.apply(A, lc; dims=:)
             end
 
             @testset "dims = 1" begin
@@ -133,8 +141,8 @@
 
         @testset "specified inds" begin
             A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            @test FeatureTransforms.apply(A, lc; dims=1, inds=[1, 2]) == [-3, -3, -2]
-            @test lc(A; dims=1, inds=[1, 2]) == [-3, -3, -2]
+            @test FeatureTransforms.apply(A, lc; inds=[1, 2]) == [-3, -3, -2]
+            @test lc(A; inds=[1, 2]) == [-3, -3, -2]
         end
 
         @testset "apply_append" begin
@@ -153,13 +161,13 @@
         lc = LinearCombination([1, -1])
 
         @testset "all inds" begin
-            @test FeatureTransforms.apply(A, lc; dims=1) == [-3, -3]
-            @test lc(A; dims=1) == [-3, -3]
+            @test FeatureTransforms.apply(A, lc) == [-3, -3]
+            @test lc(A) == [-3, -3]
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
-                @test_throws MethodError FeatureTransforms.apply(A, lc; dims=:)
+                @test_deprecated FeatureTransforms.apply(A, lc; dims=:)
             end
 
             @testset "dims = 1" begin
@@ -182,8 +190,8 @@
 
         @testset "specified inds" begin
             A = KeyedArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            @test FeatureTransforms.apply(A, lc; dims=1, inds=[1, 2]) == [-3, -3, -2]
-            @test lc(A; dims=1, inds=[1, 2]) == [-3, -3, -2]
+            @test FeatureTransforms.apply(A, lc; inds=[1, 2]) == [-3, -3, -2]
+            @test lc(A; inds=[1, 2]) == [-3, -3, -2]
         end
 
         @testset "apply_append" begin

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -9,8 +9,8 @@
         @testset "all inds" begin
             x = [1, 2]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(x, lc) == fill(-1)
-            @test lc(x) == fill(-1)
+            @test FeatureTransforms.apply(x, lc; dims=1) == fill(-1)
+            @test lc(x; dims=1) == fill(-1)
         end
 
         @testset "dims behaviour" begin
@@ -23,44 +23,36 @@
         @testset "dimension mismatch" begin
             x = [1, 2, 3]
             lc = LinearCombination([1, -1])
-            @test_throws DimensionMismatch FeatureTransforms.apply(x, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(x, lc, dims=1)
         end
 
         @testset "specified inds" begin
             x = [1, 2, 3]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(x, lc; inds=[2, 3]) == fill(-1)
-            @test lc(x; inds=[2, 3]) == fill(-1)
+            @test FeatureTransforms.apply(x, lc; dims=1, inds=[2, 3]) == fill(-1)
+            @test lc(x; dims=1, inds=[2, 3]) == fill(-1)
         end
 
         @testset "output is different type" begin
             x = [1, 2]
             lc = LinearCombination([.1, -.1])
-            @test FeatureTransforms.apply(x, lc) == fill(-.1)
-            @test lc(x) == fill(-.1)
+            @test FeatureTransforms.apply(x, lc, dims=1) == fill(-.1)
+            @test lc(x; dims=1) == fill(-.1)
         end
 
         @testset "apply_append" begin
             x = [1, 2]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply_append(x, lc; append_dim=1) == [1, 2, -1]
+            @test FeatureTransforms.apply_append(x, lc; dims=1, append_dim=1) == [1, 2, -1]
         end
     end
 
     @testset "Matrix" begin
-
-        @testset "default reduces over columns" begin
-            M = [1 1; 2 2; 3 5]
-            lc = LinearCombination([1, -1, 1])
-            @test FeatureTransforms.apply(M, lc) == [2, 4]
-            @test lc(M) == [2, 4]
-        end
-
         @testset "dims" begin
             @testset "dims = :" begin
                 M = [1 1; 2 2; 3 5]
                 lc = LinearCombination([1, -1, 1])
-                @test_throws ArgumentError FeatureTransforms.apply(M, lc; dims=:)
+                @test_throws MethodError FeatureTransforms.apply(M, lc; dims=:)
             end
 
             @testset "dims = 1" begin
@@ -80,14 +72,14 @@
         @testset "dimension mismatch" begin
             M = [1 1 1; 2 2 2]
             lc = LinearCombination([1, -1, 1])  # there are only 2 rows
-            @test_throws DimensionMismatch FeatureTransforms.apply(M, lc)
+            @test_throws DimensionMismatch FeatureTransforms.apply(M, lc; dims=1)
         end
 
         @testset "specified inds" begin
             M = [1 1; 5 2; 2 4]
             lc = LinearCombination([1, -1])
-            @test FeatureTransforms.apply(M, lc; inds=[2, 3]) == [3, -2]
-            @test lc(M; inds=[2, 3]) == [3, -2]
+            @test FeatureTransforms.apply(M, lc; dims=1, inds=[2, 3]) == [3, -2]
+            @test lc(M; dims=1, inds=[2, 3]) == [3, -2]
         end
 
         @testset "apply_append" begin
@@ -105,8 +97,8 @@
     @testset "N-dim Array" begin
         A = reshape(1:27, 3, 3, 3)
         lc = LinearCombination([1, -1, 1])
-        @test FeatureTransforms.apply(A, lc) == [2 11 20; 5 14 23; 8 17 26]
-        @test lc(A) == [2 11 20; 5 14 23; 8 17 26]
+        @test FeatureTransforms.apply(A, lc; dims=1) == [2 11 20; 5 14 23; 8 17 26]
+        @test lc(A; dims=1) == [2 11 20; 5 14 23; 8 17 26]
     end
 
     @testset "AxisArray" begin
@@ -114,13 +106,13 @@
         lc = LinearCombination([1, -1])
 
         @testset "all inds" begin
-            @test FeatureTransforms.apply(A, lc) == [-3, -3]
-            @test lc(A) == [-3, -3]
+            @test FeatureTransforms.apply(A, lc; dims=1) == [-3, -3]
+            @test lc(A; dims=1) == [-3, -3]
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
-                @test_throws ArgumentError FeatureTransforms.apply(A, lc; dims=:)
+                @test_throws MethodError FeatureTransforms.apply(A, lc; dims=:)
             end
 
             @testset "dims = 1" begin
@@ -141,8 +133,8 @@
 
         @testset "specified inds" begin
             A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            @test FeatureTransforms.apply(A, lc; inds=[1, 2]) == [-3, -3, -2]
-            @test lc(A; inds=[1, 2]) == [-3, -3, -2]
+            @test FeatureTransforms.apply(A, lc; dims=1, inds=[1, 2]) == [-3, -3, -2]
+            @test lc(A; dims=1, inds=[1, 2]) == [-3, -3, -2]
         end
 
         @testset "apply_append" begin
@@ -161,13 +153,13 @@
         lc = LinearCombination([1, -1])
 
         @testset "all inds" begin
-            @test FeatureTransforms.apply(A, lc) == [-3, -3]
-            @test lc(A) == [-3, -3]
+            @test FeatureTransforms.apply(A, lc; dims=1) == [-3, -3]
+            @test lc(A; dims=1) == [-3, -3]
         end
 
         @testset "dims" begin
             @testset "dims = :" begin
-                @test_throws ArgumentError FeatureTransforms.apply(A, lc; dims=:)
+                @test_throws MethodError FeatureTransforms.apply(A, lc; dims=:)
             end
 
             @testset "dims = 1" begin
@@ -190,8 +182,8 @@
 
         @testset "specified inds" begin
             A = KeyedArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            @test FeatureTransforms.apply(A, lc; inds=[1, 2]) == [-3, -3, -2]
-            @test lc(A; inds=[1, 2]) == [-3, -3, -2]
+            @test FeatureTransforms.apply(A, lc; dims=1, inds=[1, 2]) == [-3, -3, -2]
+            @test lc(A; dims=1, inds=[1, 2]) == [-3, -3, -2]
         end
 
         @testset "apply_append" begin

--- a/test/one_hot_encoding.jl
+++ b/test/one_hot_encoding.jl
@@ -147,8 +147,8 @@
         nt = (a = ["foo", "bar"], b = ["foo2", "bar2"])
 
         @testset "all cols" begin
-            expected = NamedTuple{Tuple(Symbol.(:Column, x) for x in 1:10)}(
-               ([1, 0], [0, 1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [1, 0], [0, 1])
+            expected = NamedTuple{Tuple(Symbol.(:Column, x) for x in 1:5)}(
+               eachcol(Bool[1 0 0 0 0; 0 1 0 0 0; 0 0 0 1 0; 0 0 0 0 1])
             )
             @test FeatureTransforms.apply(nt, ohe) == expected
             @test ohe(nt) == expected
@@ -175,14 +175,14 @@
 
         df = DataFrame(:a => ["foo", "bar"], :b => ["foo2", "bar2"])
         expected = DataFrame(
-            [[1, 0], [0, 1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [1, 0], [0, 1]],
-            [Symbol.(:Column, x) for x in 1:10],
+            Bool[1 0 0 0 0; 0 1 0 0 0; 0 0 0 1 0; 0 0 0 0 1],
+            [Symbol.(:Column, x) for x in 1:5],
         )
 
         @test FeatureTransforms.apply(df, ohe) == expected
 
-        @test FeatureTransforms.apply(df, ohe; cols=[:a]) == expected[:, 1:5]
-        @test FeatureTransforms.apply(df, ohe; cols=:a) == expected[:, 1:5]
+        @test FeatureTransforms.apply(df, ohe; cols=[:a]) == expected[1:2, :]
+        @test FeatureTransforms.apply(df, ohe; cols=:a) == expected[1:2, :]
 
         expected = DataFrame(
             [[false, false], [false, false], [false, false], [true, false], [false, true]],
@@ -191,7 +191,7 @@
         @test FeatureTransforms.apply(df, ohe; cols=[:b]) == expected
 
         @testset "apply_append" begin
-            @test FeatureTransforms.apply_append(df, ohe) == hcat(df, ohe(df))
+            @test_throws DimensionMismatch FeatureTransforms.apply_append(df, ohe)
         end
     end
 end


### PR DESCRIPTION
Second step in #75 

replaces #77 


Note I haven't changed the LinearCombination tests to prevent this being a breaking change. Instead I added a deprecation warning if `dims=:` is passed in.