### PR TITLE
Support RowTables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureTransforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using FeatureTransforms
 using FeatureTransforms: _periodic
 using FeatureTransforms: cardinality, OneToOne, OneToMany, ManyToOne, ManyToMany
 using FeatureTransforms.TestUtils
-using Tables: columntable, istable, rowtable
+using Tables: columntable, isrowtable, istable, rowtable
 using Test
 using TimeZones
 

--- a/test/types/tables.jl
+++ b/test/types/tables.jl
@@ -1,5 +1,4 @@
-# TODO: test on rowtable https://github.com/invenia/FeatureTransforms.jl/issues/64
-@testset "$TableType" for TableType in (columntable, DataFrame)
+@testset "$TableType" for TableType in (columntable, rowtable, DataFrame)
 
     table = TableType((a=[1, 2, 3], b=[4, 5, 6]))
 
@@ -91,17 +90,22 @@
     @testset "apply!" begin
         T = FakeOneToOneTransform()
 
-        _table = deepcopy(table)
-        FeatureTransforms.apply!(_table, T)
-        @test _table == TableType((a=ones(3), b=ones(3)))
+        # Cannot mutate NamedTuple elements
+        if isrowtable(table)
+            @test_throws MethodError FeatureTransforms.apply!(table, T)
+        else
+            _table = deepcopy(table)
+            FeatureTransforms.apply!(_table, T)
+            @test _table == TableType((a=ones(3), b=ones(3)))
 
-        _table = deepcopy(table)
-        FeatureTransforms.apply!(_table, T; cols=:a)
-        @test _table == TableType((a=[1, 1, 1], b=[4, 5, 6]))
+            _table = deepcopy(table)
+            FeatureTransforms.apply!(_table, T; cols=:a)
+            @test _table == TableType((a=[1, 1, 1], b=[4, 5, 6]))
 
-        _table = deepcopy(table)
-        @test_broken FeatureTransforms.apply!(_table, T; cols=:b, dims=[1, 2])
-        @test_broken _table == TableType((a=[1, 2, 3], b=[1, 1, 6]))
+            _table = deepcopy(table)
+            @test_broken FeatureTransforms.apply!(_table, T; cols=:b, dims=[1, 2])
+            @test_broken _table == TableType((a=[1, 2, 3], b=[1, 1, 6]))
+        end
     end
 
     @testset "apply_append" begin


### PR DESCRIPTION
Closes #64 

Note that we cannot call `apply!` on rowtables since the elements of the NamedTuple are immutable in this instance.

e.g. 
```julia
# can mutate the vector elements
coltable = NamedTuple{(:a, :b)}(a=[1, 2, 3], b=[4, 5, 6])

# cannot mutate the integer elements
rowtable = [
    NamedTuple{(:a, :b)}(a=1, b=4), 
    NamedTuple{(:a, :b)}(a=2, b=5), 
    NamedTuple{(:a, :b)}(a=3, b=6),
]
```

Converting to-from a columntable defeats the purpose as it wouldn't be mutating the underlying data in memory.
So we just don't support it.