### PR TITLE
test dependency on DataFrames update compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureTransforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -13,7 +13,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 AxisArrays = "0.4"
 AxisKeys = "0.1"
-DataFrames = "0.22"
+DataFrames = "0.22, 1"
 Documenter = "0.26"
 NamedDims = "0.2.32"
 Tables = "1.3"


### PR DESCRIPTION
Nightly CI on Julia 1.3 started failing last night (I don't know what change caused it) but essentially the issue is that on older julia versions the package resolver is not willing to downgrade test-time packages only, see more detail here: https://www.oxinabox.net/2021/02/13/Julia-1.6-what-has-changed-since-1.0.html#resolver-willing-to-downgrade-packages-to-install-new-ones-tiered-resolution

It turns out that we can simply update the DataFrames compat to 1 to fix it.