### PR TITLE
Drop support for Julia 1.5 and older

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.3"
+          - "1.6"
           - "1"    # Latest Release
         os:
           - ubuntu-latest
@@ -30,11 +30,6 @@ jobs:
             arch: x86
           - os: windows-latest
             arch: x86
-        include:
-          # Add a 1.5 job because that's what Invenia actually uses
-          - os: ubuntu-latest
-            version: 1.5
-            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureTransforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.3.12"
+version = "0.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -17,7 +17,7 @@ DataFrames = "0.22, 1"
 Documenter = "0.26"
 NamedDims = "0.2.32"
 Tables = "1.3"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"


### PR DESCRIPTION
This seemed like the easier options since Documenter dropped these Julia version a couple weeks ago and is now causing compat issues. 

https://github.com/invenia/FeatureTransforms.jl/actions/runs/2786559009